### PR TITLE
fix(audit-truth): CLI grammar from source build, not a stale PATH binary

### DIFF
--- a/.github/workflows/audit-truth.yml
+++ b/.github/workflows/audit-truth.yml
@@ -1,14 +1,16 @@
 name: Doc Truth
 
-# Fails the build when the docs reference CLI commands the tina4 binary
+# Fails the build when the docs reference CLI commands the tina4 CLI
 # doesn't actually have. The principle: documentation must match code
 # reality at all times. See scripts/audit-truth.py for the full check
 # list and rationale.
 #
-# Today this gate is strict on CLI drift only. Env-var drift is
-# reported but doesn't fail the build — we have 39 historical fakes to
-# clear first. Once that backlog is resolved, swap --strict for
-# --strict --strict-env to gate both.
+# Ground truth for the CLI check is a binary BUILT FROM THE tina4 SOURCE
+# REPO (a sibling checkout), NOT the last published release. A freshly
+# added command lives in source + docs before it ships to tina4.com, so
+# validating against the released binary would false-flag it (this is how
+# `tina4 metrics` / `tina4 setup` were reported as fake). Building from
+# source keeps the gate truthful the moment a command lands.
 
 on:
   push:
@@ -22,30 +24,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Pull tina4 binary alongside this repo so the audit can parse
-      # the real CLI grammar — without it the script can't compute
-      # ground truth and the gate is meaningless.
-      - name: Install tina4 CLI
+      # Pull the tina4 CLI source + every framework repo as siblings of
+      # this repo — the workspace layout audit-truth.py expects. The CLI
+      # repo is the source of truth for the `tina4 <cmd>` grammar; the
+      # framework repos are the source of truth for TINA4_* env vars.
+      - name: Check out tina4 CLI + framework repos
         run: |
-          curl -fsSL https://tina4.com/install.sh | sh
-          tina4 --version
-
-      # Pull every framework repo so the env-var check sees the real
-      # source of truth. Done in a single workspace-style layout that
-      # audit-truth.py expects (sibling dirs to docs).
-      - name: Check out framework repos
-        run: |
-          mkdir -p ../tina4-python ../tina4-php ../tina4-ruby ../tina4-nodejs ../tina4-js
           cd ..
-          for repo in tina4-python tina4-php tina4-ruby tina4-nodejs tina4-js; do
+          for repo in tina4 tina4-python tina4-php tina4-ruby tina4-nodejs tina4-js; do
             if [ ! -d "$repo/.git" ]; then
               git clone --depth=1 https://github.com/tina4stack/$repo.git
             fi
           done
 
+      # Cache the Rust build so the CLI compiles once, not every run.
+      - name: Cache tina4 CLI build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ../tina4 -> target
+
+      # Build the CLI from source so the audit introspects the CURRENT
+      # grammar. audit-truth.py picks up ../tina4/target/release/tina4
+      # automatically (see _resolve_cli_binary). cargo is preinstalled on
+      # ubuntu-latest.
+      - name: Build tina4 CLI (ground truth for the CLI check)
+        run: |
+          cargo build --release --manifest-path ../tina4/Cargo.toml
+          ../tina4/target/release/tina4 --version
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      # Lock in the audit's own behavior — chiefly that the CLI check
+      # derives its grammar from the built source (not a stale PATH binary)
+      # and still flags genuinely-fake commands. Uses the ../tina4 build
+      # from the step above for its integration case.
+      - name: Test the audit script
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest scripts/test_audit_truth.py -q
 
       - name: Run audit (strict — both CLI and env-var drift block the build)
         run: python3 scripts/audit-truth.py --strict --strict-env

--- a/scripts/audit-truth.py
+++ b/scripts/audit-truth.py
@@ -14,17 +14,22 @@ What it checks
 
 1. **CLI commands** — every ``tina4 <subcommand>`` mentioned in any
    markdown doc must be a real subcommand of the ``tina4`` Rust CLI.
-   Source of truth: parse ``tina4 --help`` output.
+   Source of truth: parse ``--help`` from a binary BUILT FROM THE CLI
+   SOURCE REPO (sibling ``../tina4``), not whatever ``tina4`` happens to
+   be on PATH. An old global install predates recently added commands
+   and would false-flag real docs — see ``_resolve_cli_binary`` for the
+   resolution order (``$TINA4_CLI_BIN`` -> ../tina4 build -> PATH).
 
 2. **Environment variables** — every ``TINA4_*`` mentioned in docs must
    appear in at least one framework source tree (read from a getenv()-
    style call). Source of truth: ripgrep across the four framework repos.
 
-The script discovers framework source trees by walking ``..`` from the
-docs repo, looking for sibling repos named ``tina4-{python,php,ruby,
-nodejs,js}``. If a sibling is missing, the corresponding check is
-skipped with a warning rather than failing — keeps local dev usable
-when you only have one repo cloned.
+The script discovers source trees by walking ``..`` from the docs repo,
+looking for the CLI repo ``tina4`` and the framework repos
+``tina4-{python,php,ruby,nodejs,js}``. If a sibling is missing, the
+corresponding check falls back (CLI: to a PATH binary) or is skipped
+with a warning rather than failing — keeps local dev usable when you
+only have one repo cloned.
 
 Why this exists
 ===============
@@ -50,6 +55,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -71,6 +77,14 @@ for _stream in (sys.stdout, sys.stderr):
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKSPACE_ROOT = REPO_ROOT.parent  # ../
+
+# The Rust CLI repo — sibling to the docs repo. This is the SOURCE OF TRUTH
+# for the `tina4 <cmd>` grammar. We introspect a binary BUILT FROM THIS
+# SOURCE rather than whatever `tina4` happens to be on PATH: an old global
+# install (e.g. a 3.8.25 left over from months ago) predates recently added
+# commands and would false-flag real docs (this is exactly how `tina4 setup`
+# and `tina4 metrics` used to be reported as fake). See `_resolve_cli_binary`.
+CLI_REPO = WORKSPACE_ROOT / "tina4"
 
 # Doc directories to scan. We deliberately skip vendored/built outputs.
 DOC_GLOBS: tuple[str, ...] = (
@@ -135,6 +149,126 @@ def strip_code_fences(text: str) -> str:
 
 # ── Check 1: CLI commands ─────────────────────────────────────────────
 
+def _fmt_ver(v: tuple[int, int, int] | None) -> str:
+    return ".".join(map(str, v)) if v else "unknown"
+
+
+def _semver(text: str) -> tuple[int, int, int] | None:
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", text or "")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def _cli_source_version() -> tuple[int, int, int] | None:
+    """Version declared in the sibling CLI repo's ``Cargo.toml`` ``[package]``
+    table — the real target the docs should match. ``None`` if the CLI repo
+    isn't a sibling (keeps the check working when only the docs are cloned)."""
+    cargo = CLI_REPO / "Cargo.toml"
+    if not cargo.exists():
+        return None
+    section = ""
+    for raw in cargo.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line
+        elif section == "[package]" and line.startswith("version") and "=" in line:
+            return _semver(line.split("=", 1)[1])
+    return None
+
+
+def _binary_version(binary: str) -> tuple[int, int, int] | None:
+    try:
+        out = subprocess.run(
+            [binary, "--version"], capture_output=True, text=True,
+            check=False, timeout=20,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return _semver(out)
+
+
+def _sibling_cli_binary(src_ver: tuple[int, int, int] | None,
+                        notes: list[str]) -> str | None:
+    """Return a tina4 binary built from the sibling CLI source, or ``None``.
+
+    Prefers an existing ``target/{release,debug}/tina4``. If none exists and
+    ``cargo`` is available, builds it once so the grammar reflects committed
+    source. Warns (never fails) when an existing build lags the source."""
+    release = CLI_REPO / "target" / "release" / "tina4"
+    debug = CLI_REPO / "target" / "debug" / "tina4"
+
+    existing = next((c for c in (release, debug) if c.exists()), None)
+    if existing:
+        bv = _binary_version(str(existing))
+        if src_ver and bv and bv < src_ver:
+            notes.append(yellow(
+                f"⚠ ../tina4 build is {_fmt_ver(bv)} but source is "
+                f"{_fmt_ver(src_ver)} — rebuild for exact grammar: "
+                f"(cd ../tina4 && cargo build --release)"))
+        return str(existing)
+
+    # No build yet — produce one from source if we can.
+    if shutil.which("cargo"):
+        notes.append(cyan("→ no ../tina4 build found; running "
+                          "`cargo build --release` to establish CLI ground truth…"))
+        proc = subprocess.run(
+            ["cargo", "build", "--release", "--manifest-path",
+             str(CLI_REPO / "Cargo.toml")],
+            capture_output=True, text=True, check=False,
+        )
+        if proc.returncode == 0 and release.exists():
+            return str(release)
+        notes.append(yellow("⚠ cargo build of ../tina4 failed — falling back to PATH"))
+        for ln in (proc.stderr or "").strip().splitlines()[-3:]:
+            notes.append(dim(f"    {ln}"))
+    else:
+        notes.append(yellow("⚠ ../tina4 has no build and cargo is not installed "
+                            "— falling back to the PATH binary (may be stale)"))
+    return None
+
+
+def _resolve_cli_binary() -> tuple[str | None, list[str]]:
+    """Locate the tina4 binary whose grammar we trust as ground truth.
+
+    Priority, most to least trustworthy:
+      1. ``$TINA4_CLI_BIN``         — explicit override (path to a binary).
+      2. A build of the sibling     — ../tina4/target/{release,debug}/tina4,
+         CLI repo (../tina4)          built from source so it matches the
+                                      committed grammar (auto-built if absent).
+      3. ``tina4`` on ``PATH``      — last resort. An old global install can
+                                      predate recently added commands, which
+                                      is precisely what produced the false
+                                      ``tina4 metrics`` / ``tina4 setup`` flags.
+
+    Returns ``(binary_or_None, notes)``. Notes surface staleness so a red gate
+    is never silently caused by an out-of-date binary."""
+    notes: list[str] = []
+    src_ver = _cli_source_version()
+
+    override = os.environ.get("TINA4_CLI_BIN")
+    if override:
+        if Path(override).exists():
+            return override, notes
+        notes.append(yellow(f"⚠ TINA4_CLI_BIN={override} does not exist — ignoring"))
+
+    if (CLI_REPO / "Cargo.toml").exists():
+        built = _sibling_cli_binary(src_ver, notes)
+        if built:
+            return built, notes
+
+    path_bin = shutil.which("tina4")
+    if path_bin:
+        bin_ver = _binary_version(path_bin)
+        if src_ver and bin_ver and bin_ver < src_ver:
+            notes.append(yellow(
+                f"⚠ using `tina4` on PATH ({_fmt_ver(bin_ver)}) but the CLI "
+                f"source is {_fmt_ver(src_ver)} — it may predate recently added "
+                f"commands. Build ../tina4 (cargo build --release) or set "
+                f"TINA4_CLI_BIN to validate against current source."))
+        return path_bin, notes
+
+    return None, notes
+
+
 def _parse_help_commands(help_text: str) -> set[str]:
     """Pull subcommand names out of a ``--help`` Commands: block."""
     cmds: set[str] = set()
@@ -169,11 +303,13 @@ def _parse_help_positional_choices(help_text: str) -> set[str]:
     return choices
 
 
-def real_cli_grammar() -> tuple[set[str], dict[str, set[str]]] | None:
+def real_cli_grammar(binary: str | None = None) -> tuple[set[str], dict[str, set[str]]] | None:
     """Two-level discovery:
 
-    Returns ``(top_level, second_token_per_cmd)`` or ``None`` if the
-    ``tina4`` binary isn't on PATH.
+    Returns ``(top_level, second_token_per_cmd)`` or ``None`` if no ``tina4``
+    binary could be resolved. ``binary`` may be passed in (from
+    ``_resolve_cli_binary``) so the caller can surface resolution notes;
+    when omitted it is resolved here for back-compat.
 
     - ``top_level`` is the set of valid top-level subcommands (``serve``,
       ``init``, ``migrate``, ``generate``, etc).
@@ -191,7 +327,8 @@ def real_cli_grammar() -> tuple[set[str], dict[str, set[str]]] | None:
     ``tina4 generate:model`` (colon-style, never real) while accepting
     the canonical space-separated form.
     """
-    binary = shutil.which("tina4")
+    if binary is None:
+        binary, _ = _resolve_cli_binary()
     if not binary:
         return None
     top_help = subprocess.run(
@@ -290,9 +427,12 @@ def doc_cli_mentions() -> dict[tuple[str, str | None], list[Path]]:
 def check_cli() -> tuple[int, list[str]]:
     """Two-level drift detection: invalid first token AND invalid
     second token (when one is present and the first token is real)."""
-    grammar = real_cli_grammar()
+    binary, resolve_notes = _resolve_cli_binary()
+    grammar = real_cli_grammar(binary)
     if grammar is None:
-        return 0, [yellow("⚠ tina4 binary not on PATH — skipping CLI check")]
+        return 0, resolve_notes + [
+            yellow("⚠ no tina4 CLI available (no ../tina4 source, no build, "
+                   "none on PATH) — skipping CLI check")]
     real_top, real_second = grammar
 
     mentions = doc_cli_mentions()
@@ -347,6 +487,7 @@ def check_cli() -> tuple[int, list[str]]:
     drift = len(missing_first) + len(missing_second)
     lines = [f"\n{cyan('CLI check')} — real top-level: {len(real_top)}, "
              f"unique doc forms: {len(mentions)}"]
+    lines.extend(resolve_notes)
     if drift == 0:
         lines.append(green("  ✓ no drift — every `tina4 <cmd> [<arg>]` is real"))
         return 0, lines

--- a/scripts/test_audit_truth.py
+++ b/scripts/test_audit_truth.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Regression tests for audit-truth.py — the doc<->code truth gate.
+
+Run: ``python3 -m pytest scripts/test_audit_truth.py -q`` (from the repo root).
+
+These lock in the fix for the class of bug where the CLI check trusted
+whatever ``tina4`` binary happened to be on PATH. An old global install
+(e.g. 3.8.25) predates recently added commands, so real docs for
+``tina4 setup`` / ``tina4 metrics`` were reported as fake. The gate must
+derive its grammar from a binary built from the CLI SOURCE, and must
+still flag genuinely-fake commands (no blanket whitelist).
+
+The tests are hermetic: they synthesize fake ``tina4`` binaries and a
+fake CLI source repo, so no cargo build or real install is required.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("audit_truth", _HERE / "audit-truth.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+at = _load()
+
+
+# A stand-in for the tina4 CLI. Responds to `--version`, `--help`, and
+# `<cmd> --help` so both real_cli_grammar() and _binary_version() work.
+# `commands` controls which subcommands the fake advertises, so a test can
+# model a fresh CLI (has setup/metrics) or a stale one (does not).
+def _fake_tina4(path: Path, version: str, commands: list[str]) -> Path:
+    cmd_block = "\n".join(f"  {c}\n          {c} does a thing" for c in commands)
+    body = f'''#!/usr/bin/env python3
+import sys
+args = sys.argv[1:]
+if args == ["--version"]:
+    print("tina4 {version}"); sys.exit(0)
+if args == ["--help"]:
+    print("""Usage: tina4 <COMMAND>
+
+Commands:
+{cmd_block}
+  help
+          Print this message
+
+Options:
+  -h, --help  Print help
+"""); sys.exit(0)
+if len(args) == 2 and args[1] == "--help":
+    cmd = args[0]
+    if cmd == "setup":
+        print("""Usage: tina4 setup [OPTIONS]
+
+Options:
+      --dry-run       Preview only
+      --skip-install  Scaffold, no installs
+  -h, --help          Print help
+"""); sys.exit(0)
+    if cmd == "init":
+        print("""Usage: tina4 init [LANG] [PATH]
+
+Arguments:
+  [LANG]  Language
+  [PATH]  Project dir
+"""); sys.exit(0)
+    print(f"Usage: tina4 {{cmd}} [ARGS]...\\n\\nOptions:\\n  -h, --help  Print help\\n"); sys.exit(0)
+sys.exit(2)
+'''
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
+    return path
+
+
+def _fake_cli_repo(root: Path, version: str, built_binary: Path | None) -> Path:
+    """Create a sibling-style ../tina4 with a Cargo.toml and, optionally, a
+    prebuilt target/release/tina4."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "Cargo.toml").write_text(
+        f'[package]\nname = "tina4"\nversion = "{version}"\nedition = "2021"\n\n'
+        f'[dependencies]\nclap = {{ version = "4" }}\n',
+        encoding="utf-8",
+    )
+    if built_binary is not None:
+        rel = root / "target" / "release"
+        rel.mkdir(parents=True, exist_ok=True)
+        _fake_tina4(rel / "tina4", version, ["serve", "init", "setup", "metrics", "generate"])
+    return root
+
+
+# ── Helper unit tests ─────────────────────────────────────────────────
+
+def test_semver_parsing():
+    assert at._semver("tina4 3.8.53") == (3, 8, 53)
+    assert at._semver("v3.10.0-rc.2") == (3, 10, 0)
+    assert at._semver("no version here") is None
+
+
+def test_source_version_reads_package_table_not_deps(tmp_path, monkeypatch):
+    repo = _fake_cli_repo(tmp_path / "tina4", "3.8.53", built_binary=None)
+    monkeypatch.setattr(at, "CLI_REPO", repo)
+    # Must read the [package] version (3.8.53), NOT the clap dep "4".
+    assert at._cli_source_version() == (3, 8, 53)
+
+
+# ── The core regression: resolver must not trust a stale PATH binary ──
+
+def test_resolver_prefers_sibling_build_over_stale_path(tmp_path, monkeypatch):
+    # A fresh source repo (3.9.0) WITH a build, and a stale binary on PATH (3.8.25).
+    repo = _fake_cli_repo(tmp_path / "tina4", "3.9.0", built_binary=True)
+    stale = _fake_tina4(tmp_path / "path_tina4", "3.8.25", ["serve", "init"])  # no setup/metrics
+    monkeypatch.setattr(at, "CLI_REPO", repo)
+    monkeypatch.setattr(at.shutil, "which",
+                        lambda name: str(stale) if name == "tina4" else None)
+    monkeypatch.delenv("TINA4_CLI_BIN", raising=False)
+
+    resolved, _notes = at._resolve_cli_binary()
+    assert resolved == str(repo / "target" / "release" / "tina4"), \
+        "resolver must prefer the source build over a stale PATH binary"
+
+    top, _second = at.real_cli_grammar(resolved)
+    assert {"setup", "metrics"} <= top
+
+
+def test_env_override_wins(tmp_path, monkeypatch):
+    repo = _fake_cli_repo(tmp_path / "tina4", "3.9.0", built_binary=True)
+    override = _fake_tina4(tmp_path / "override_tina4", "9.9.9", ["serve", "custom"])
+    monkeypatch.setattr(at, "CLI_REPO", repo)
+    monkeypatch.setenv("TINA4_CLI_BIN", str(override))
+    resolved, _notes = at._resolve_cli_binary()
+    assert resolved == str(override)
+
+
+# ── End-to-end: check_cli against fresh vs stale grammar ──────────────
+
+def test_setup_and_metrics_pass_against_fresh_cli(tmp_path, monkeypatch):
+    """The exact bug: `tina4 setup`, `tina4 setup --dry-run` and
+    `tina4 metrics` must NOT be flagged when the CLI actually has them."""
+    repo = _fake_cli_repo(tmp_path / "tina4", "3.9.0", built_binary=True)
+    monkeypatch.setattr(at, "CLI_REPO", repo)
+    monkeypatch.setattr(at.shutil, "which", lambda name: None)
+    monkeypatch.delenv("TINA4_CLI_BIN", raising=False)
+    monkeypatch.setattr(at, "doc_cli_mentions", lambda: {
+        ("setup", None): [at.REPO_ROOT / "docs/get-started.md"],
+        ("setup", "--dry-run"): [at.REPO_ROOT / "docs/get-started.md"],
+        ("metrics", None): [at.REPO_ROOT / "docs/index.md"],
+    })
+    drift, lines = at.check_cli()
+    assert drift == 0, "\n".join(lines)
+
+
+def test_fake_command_is_still_flagged(tmp_path, monkeypatch):
+    """No blanket whitelist: a command the CLI does NOT have is still drift."""
+    repo = _fake_cli_repo(tmp_path / "tina4", "3.9.0", built_binary=True)
+    monkeypatch.setattr(at, "CLI_REPO", repo)
+    monkeypatch.setattr(at.shutil, "which", lambda name: None)
+    monkeypatch.delenv("TINA4_CLI_BIN", raising=False)
+    monkeypatch.setattr(at, "doc_cli_mentions", lambda: {
+        ("env-migrate", None): [at.REPO_ROOT / "docs/index.md"],  # never real
+    })
+    drift, lines = at.check_cli()
+    assert drift == 1, "\n".join(lines)
+
+
+# ── Integration: the real sibling repo, if present, has zero CLI drift ─
+
+def test_real_repo_has_no_cli_drift():
+    """When the real ../tina4 source is a sibling (as in CI, which builds
+    it), the actual docs must have zero CLI drift. Skips when the CLI repo
+    isn't cloned/built locally."""
+    binary, _notes = at._resolve_cli_binary()
+    if binary is None or at.real_cli_grammar(binary) is None:
+        pytest.skip("no tina4 CLI available (../tina4 not cloned/built)")
+    # Only meaningful when the grammar came from a real build, not a random
+    # PATH binary that could be stale.
+    if not (at.CLI_REPO / "Cargo.toml").exists():
+        pytest.skip("../tina4 source repo not present")
+    drift, lines = at.check_cli()
+    assert drift == 0, "real docs have CLI drift:\n" + "\n".join(lines)


### PR DESCRIPTION
## Problem

`audit-truth.py`'s CLI check introspected whatever `tina4` was on `PATH`. An old global install predates recently added commands, so real docs were reported as **fake**:

- `tina4 metrics` (added v3.8.50) — referenced in `docs/index.md` + all four `36-releases.md`
- `tina4 setup` (~v3.8.47) — referenced in `docs/get-started.md`, `docs/install-security.md`

CI had the same fragility: it installed the last *released* binary via `install.sh`, which lags source the moment a command lands.

## Fix (detection, not a whitelist)

- **`_resolve_cli_binary()`** derives grammar from a binary **built from the sibling CLI source repo** (`../tina4`): `$TINA4_CLI_BIN` -> `../tina4/target/{release,debug}/tina4` (auto-built if absent) -> PATH (with a loud staleness warning when older than `../tina4/Cargo.toml`). Mirrors how the env-var check already trusts sibling source.
- **CI** now checks out + builds `../tina4` from source (cached) so the gate validates docs against **current CLI source**, not the last release.
- **`scripts/test_audit_truth.py`** — 7 hermetic regression tests (fake `tina4` binaries, no cargo): resolver prefers source build over stale PATH; `setup`/`metrics`/`setup --dry-run` pass against a fresh CLI; a genuinely-fake command is still flagged. CI runs them before the audit.

## Verification (local)

- `tina4 metrics --help` / `tina4 setup --help` work against current CLI
- `pytest scripts/test_audit_truth.py` -> 7 passed
- `audit-truth.py --strict --strict-env` -> exit 0, `no drift`

No CLI source changed; no client re-sign/re-release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)