### PR TITLE
install-skills: ship six skills for 3.13.58 (per-language developer split)

### DIFF
--- a/docs/public/install-skills.ps1
+++ b/docs/public/install-skills.ps1
@@ -1,39 +1,46 @@
 # Tina4 AI skills installer for Windows
 # Usage: irm https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.ps1 | iex
 #
-# Installs the tina4 AI skills (tina4-developer, tina4-js) into ~/.claude/skills
-# so Claude Desktop / Claude Code use Tina4 conventions out of the box.
+# Installs the tina4 AI skills into ~/.claude/skills so Claude Desktop / Claude Code
+# use Tina4 conventions out of the box. As of 3.13.58 the developer skill is split
+# per language (each owned by its framework repo); tina4-js + tina4-maintainer are shared.
 # Stopgap until `tina4 skills install` ships embedded in the CLI binary.
 $ErrorActionPreference = "Stop"
 
-# Pin skills to a released tag, not a moving branch, so an install is
-# reproducible and auditable. Bump this when the skills change in a new
-# tina4-python release. Override with TINA4_SKILLS_REF if you need a branch.
-$ref = if ($env:TINA4_SKILLS_REF) { $env:TINA4_SKILLS_REF } else { "3.13.56" }
-$base = "https://raw.githubusercontent.com/tina4stack/tina4-python/$ref/.claude/skills"
+# Pin skills to a released tag, not a moving branch, so an install is reproducible.
+# Bump this when the skills change in a new release. Override with TINA4_SKILLS_REF.
+$ref  = if ($env:TINA4_SKILLS_REF) { $env:TINA4_SKILLS_REF } else { "3.13.58" }
 $dest = Join-Path $HOME ".claude\skills"
 
-# skill name -> reference files
-$skills = [ordered]@{
-  "tina4-developer" = @("auth-and-services.md", "data-and-orm.md", "deployment.md", "routes-and-api.md", "templates-and-frontend.md")
-  "tina4-js"        = @("html-and-components.md", "signals-and-reactivity.md", "persistence.md")
-}
+$devRefs = @("auth-and-services.md", "data-and-orm.md", "deployment.md", "routes-and-api.md", "templates-and-frontend.md", "realtime.md")
+
+# repo, skill, reference files. Per-language developer skills come from their own
+# framework repo; tina4-js + tina4-maintainer are shared (served from tina4-python).
+$installs = @(
+  @{ repo = "tina4-python"; skill = "tina4-developer-python"; refs = $devRefs }
+  @{ repo = "tina4-php";    skill = "tina4-developer-php";    refs = $devRefs }
+  @{ repo = "tina4-ruby";   skill = "tina4-developer-ruby";   refs = $devRefs }
+  @{ repo = "tina4-nodejs"; skill = "tina4-developer-nodejs"; refs = $devRefs }
+  @{ repo = "tina4-python"; skill = "tina4-js";               refs = @("html-and-components.md", "signals-and-reactivity.md", "persistence.md", "rtc.md") }
+  @{ repo = "tina4-python"; skill = "tina4-maintainer";       refs = @("cli-and-deployment.md", "frond-and-frontend.md", "routing-and-orm.md", "subsystems.md") }
+)
 
 Write-Host ""
 Write-Host "  Tina4 Skills Installer" -ForegroundColor Cyan
-Write-Host "  Installing to: $dest" -ForegroundColor Cyan
+Write-Host "  Installing to: $dest  (ref: $ref)" -ForegroundColor Cyan
 Write-Host ""
 
-foreach ($skill in $skills.Keys) {
-  $refdir = Join-Path $dest "$skill\references"
+foreach ($i in $installs) {
+  $base   = "https://raw.githubusercontent.com/tina4stack/$($i.repo)/$ref/.claude/skills"
+  $refdir = Join-Path $dest "$($i.skill)\references"
   New-Item -ItemType Directory -Path $refdir -Force | Out-Null
-  Invoke-WebRequest -Uri "$base/$skill/SKILL.md" -OutFile (Join-Path $dest "$skill\SKILL.md")
-  foreach ($ref in $skills[$skill]) {
-    Invoke-WebRequest -Uri "$base/$skill/references/$ref" -OutFile (Join-Path $refdir $ref)
+  Invoke-WebRequest -Uri "$base/$($i.skill)/SKILL.md" -OutFile (Join-Path $dest "$($i.skill)\SKILL.md")
+  foreach ($r in $i.refs) {
+    Invoke-WebRequest -Uri "$base/$($i.skill)/references/$r" -OutFile (Join-Path $refdir $r)
   }
-  Write-Host "  + $skill" -ForegroundColor Green
+  Write-Host "  + $($i.skill)  ($($i.repo))" -ForegroundColor Green
 }
 
 Write-Host ""
-Write-Host "  Done. Restart Claude (Desktop/Code) to pick up the skills." -ForegroundColor Green
+Write-Host "  Done - six skills installed. Restart Claude (Desktop/Code) to pick them up." -ForegroundColor Green
 Write-Host ""

--- a/docs/public/install-skills.sh
+++ b/docs/public/install-skills.sh
@@ -2,36 +2,45 @@
 # Tina4 AI skills installer for macOS / Linux
 # Usage: curl -fsSL https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.sh | sh
 #
-# Installs the tina4 AI skills (tina4-developer, tina4-js) into ~/.claude/skills
-# so Claude Desktop / Claude Code use Tina4 conventions out of the box.
+# Installs the tina4 AI skills into ~/.claude/skills so Claude Desktop / Claude Code
+# use Tina4 conventions out of the box. As of 3.13.58 the developer skill is split
+# per language (each owned by its framework repo); tina4-js + tina4-maintainer are shared.
 # Stopgap until `tina4 skills install` ships embedded in the CLI binary.
 set -euo pipefail
 
-# Pin skills to a released tag, not a moving branch, so an install is
-# reproducible and auditable. Bump this when the skills change in a new
-# tina4-python release. Override with TINA4_SKILLS_REF if you need a branch.
-ref="${TINA4_SKILLS_REF:-3.13.56}"
-base="https://raw.githubusercontent.com/tina4stack/tina4-python/${ref}/.claude/skills"
+# Pin skills to a released tag, not a moving branch, so an install is reproducible.
+# Bump this when the skills change in a new release. Override with TINA4_SKILLS_REF.
+ref="${TINA4_SKILLS_REF:-3.13.58}"
 dest="$HOME/.claude/skills"
 
+# install_skill <repo> <skill> <reference.md ...>
 install_skill() {
-  skill="$1"; shift
+  repo="$1"; skill="$2"; shift 2
+  base="https://raw.githubusercontent.com/tina4stack/${repo}/${ref}/.claude/skills"
   mkdir -p "$dest/$skill/references"
   curl -fsSL "$base/$skill/SKILL.md" -o "$dest/$skill/SKILL.md"
-  for ref in "$@"; do
-    curl -fsSL "$base/$skill/references/$ref" -o "$dest/$skill/references/$ref"
+  for r in "$@"; do
+    curl -fsSL "$base/$skill/references/$r" -o "$dest/$skill/references/$r"
   done
-  echo "  + $skill"
+  echo "  + $skill  ($repo)"
 }
+
+DEV_REFS="auth-and-services.md data-and-orm.md deployment.md routes-and-api.md templates-and-frontend.md realtime.md"
 
 echo ""
 echo "  Tina4 Skills Installer"
-echo "  Installing to: $dest"
+echo "  Installing to: $dest  (ref: $ref)"
 echo ""
 
-install_skill tina4-developer auth-and-services.md data-and-orm.md deployment.md routes-and-api.md templates-and-frontend.md
-install_skill tina4-js html-and-components.md signals-and-reactivity.md persistence.md
+# Per-language developer skills (each from its own framework repo)
+install_skill tina4-python  tina4-developer-python  $DEV_REFS
+install_skill tina4-php     tina4-developer-php     $DEV_REFS
+install_skill tina4-ruby    tina4-developer-ruby    $DEV_REFS
+install_skill tina4-nodejs  tina4-developer-nodejs  $DEV_REFS
+# Shared skills (canonical copy served from tina4-python)
+install_skill tina4-python  tina4-js          html-and-components.md signals-and-reactivity.md persistence.md rtc.md
+install_skill tina4-python  tina4-maintainer  cli-and-deployment.md frond-and-frontend.md routing-and-orm.md subsystems.md
 
 echo ""
-echo "  Done. Restart Claude (Desktop/Code) to pick up the skills."
+echo "  Done — six skills installed. Restart Claude (Desktop/Code) to pick them up."
 echo ""


### PR DESCRIPTION
Mirror the canonical `tina4stack/tina4` installer so `tina4.com/install-skills.sh` (and `.ps1`) serve the split skill set: `tina4-developer-{python,php,ruby,nodejs}` (each from its own repo, with `realtime.md`) + shared `tina4-js` (incl. `rtc.md`) + `tina4-maintainer`. Bumps default ref `3.13.56` → `3.13.58`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)