### PR TITLE
docs: WebRTC / real-time collaboration for all languages + llms.txt

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,6 +14,8 @@ const TITLE_OVERRIDES: Record<string, string> = {
     'pwa': 'PWA',
     'graphql': 'GraphQL',
     'websocket': 'WebSocket',
+    'realtime-rtc': 'Real-time (WebRTC)',
+    'realtime-webrtc': 'Real-time (WebRTC)',
     'wsdl-soap': 'WSDL / SOAP',
     'sse': 'Server-Sent Events (SSE)',
     'wsdl': 'WSDL',
@@ -64,7 +66,7 @@ const SECTION_RANGES: Record<string, [number, number]> = {
     'Developer Tools': [30, 32],
     'Operations': [33, 35],
     'Releases': [36, 36],
-    'Appendix': [37, 38],
+    'Appendix': [37, 39],
 }
 
 function buildChapterSidebar(section: string, label: string, extras?: object[]): object[] {

--- a/docs/js/17-realtime-rtc.md
+++ b/docs/js/17-realtime-rtc.md
@@ -1,0 +1,491 @@
+# Chapter 17: Real-time (WebRTC)
+
+## Peer-to-Peer Without a Media Server
+
+A user clicks "Join call" and sees three other faces. Someone drops a file into the chat and it appears on every screen. Another person shares their terminal. All of it happens in the browser, live, with no polling and no round-trip through a media server you had to build and scale.
+
+The reflex is to reach for a stack: a SFU, TURN infrastructure, a signalling protocol, a chat backend, an upload service. That is a lot of moving parts before the first "hello" crosses the wire.
+
+tina4-js takes the mesh route instead. Browsers connect **directly** to each other -- audio, video, and screen share flow peer-to-peer. The server only does two small jobs: it relays the WebRTC handshake (the SDP and ICE messages) over a signalling WebSocket, and it tells the client where everything lives via one config endpoint. The media never touches your backend.
+
+The `rtc` module wraps all of it -- calls, chat, and file sharing -- behind three signal-driven functions. Bind the signals into an `html` template and the UI stays live on its own.
+
+---
+
+## 1. The `rtc` Module
+
+The client pairs with a Tina4 backend's `realtime()` mount. It has three surfaces:
+
+- **`rtc.call(room, options?)`** -- mesh WebRTC (audio / video / screen share) over a signalling WebSocket, using the perfect-negotiation pattern.
+- **`rtc.chat(channel, options?)`** -- persistent chat: messages, presence, typing indicators, read receipts, and REST history.
+- **`rtc.upload(channel, file, options?)`** / **`rtc.fetchBlob(key, options?)`** -- file transfer.
+
+Everything reactive is a `Signal<T>` from `tina4js`, so it drops straight into templates. The **new-reference rule** applies: the module replaces the signal arrays wholesale (`peers`, `messages`, `presence`, `typing`, ...). Read them; never `.push()` or mutate them in place.
+
+```typescript
+import { rtc } from 'tina4js/rtc';
+```
+
+> **`rtc.call()` is async; `rtc.chat()` is sync.** `rtc.call()` returns a `Promise` -- it fetches config and prompts for camera/mic, so you must `await` it. `rtc.chat()` returns the session synchronously -- the socket connects in the background. Mixing these up is the single most common mistake.
+
+```typescript
+const call = await rtc.call('standup');   // ← await
+const chat = rtc.chat('general');         // ← no await
+```
+
+---
+
+## 2. Bootstrapping: `GET /api/rtc/config`
+
+The client hardcodes no URLs. It asks the backend where the ICE servers and the WS/HTTP routes live, then wires itself up from the answer. `rtc.call()` does this fetch for you automatically -- but you can also call it directly:
+
+```typescript
+import { rtcConfig } from 'tina4js/rtc';
+
+const cfg = await rtcConfig();          // GET /api/rtc/config
+```
+
+It is also exposed on the object as `rtc.config` -- note that this is the **function itself** (`rtc.config === rtcConfig`), not a cached config object. Call it:
+
+```typescript
+const cfg = await rtc.config();         // same thing
+```
+
+A non-2xx response throws `[tina4] rtc config fetch failed: <status>`.
+
+### `RtcConfig`
+
+```typescript
+interface RtcConfig {
+  backend: string;
+  iceServers?: RTCIceServer[];   // STUN/TURN for the peer connections
+  signalling?: string;           // call WS path, e.g. "/ws/rtc/{room}"
+  chat?: string;                 // chat WS path, e.g. "/ws/chat/{channel}"
+  messages?: string;             // history HTTP path, e.g. "/api/channels/{id}/messages"
+  files?: string;                // upload/download path, e.g. "/api/files"
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `backend` | `string` | Backend identifier. |
+| `iceServers` | `RTCIceServer[]` | STUN/TURN servers for the peer connections. |
+| `signalling` | `string` | Call WS path template. |
+| `chat` | `string` | Chat WS path template. |
+| `messages` | `string` | REST history path template. |
+| `files` | `string` | File upload/download path. |
+
+A `{room}`, `{channel}`, or `{id}` placeholder in a path template is substituted with the value you pass. If the template has no placeholder, the client appends `/<value>` instead.
+
+### Fetch once, reuse everywhere
+
+Every `rtc.call()` fetches config unless you hand it one. If you open several rooms, fetch once and pass it along to skip the repeat network trips:
+
+```typescript
+const config = await rtc.config();
+const a = await rtc.call('room-a', { config });
+const b = await rtc.call('room-b', { config });
+```
+
+---
+
+## 3. Calls -- `rtc.call(room, options?)`
+
+Each participant opens one `RTCPeerConnection` per other participant in the room -- a full mesh. The server relays only `hello` / `welcome` / `bye` / `desc` / `ice` messages between peers; the audio and video are strictly peer-to-peer. Glare is handled for you with the perfect-negotiation pattern, so simultaneous offers never wedge the connection.
+
+```typescript
+const call = await rtc.call('standup');   // camera + mic by default
+```
+
+### `CallOptions`
+
+| Option | Type | Default | Behaviour |
+|---|---|---|---|
+| `config` | `RtcConfig` | -- | Pre-fetched config; **skips the per-call fetch**. |
+| `configUrl` | `string` | `'/api/rtc/config'` | Where to fetch config if `config` is not given. |
+| `signallingUrl` | `string` | config's `signalling` or `/ws/rtc` | Explicit WS base; `{room}` is filled or appended. |
+| `iceServers` | `RTCIceServer[]` | config's `iceServers` or `[]` | ICE server override. |
+| `media` | `MediaStreamConstraints \| MediaStream \| false` | `{ audio: true, video: true }` | Local media. A ready `MediaStream` is used as-is; `false` means **receive-only** (no `getUserMedia` prompt). |
+
+### `CallSession`
+
+```typescript
+interface CallSession {
+  readonly status: Signal<CallStatus>;              // 'idle' | 'connecting' | 'connected' | 'closed'
+  readonly localStream: Signal<MediaStream | null>; // your camera/mic (null if media: false)
+  readonly peers: Signal<RemotePeer[]>;             // remote participants + their streams
+  readonly screenSharing: Signal<boolean>;
+  readonly error: Signal<Error | null>;             // last negotiation/ICE error
+  readonly id: string;                              // this peer's id in the room
+  shareScreen(): Promise<void>;
+  stopScreen(): Promise<void>;
+  toggleAudio(on?: boolean): boolean;               // returns new enabled state
+  toggleVideo(on?: boolean): boolean;
+  leave(): void;
+}
+
+interface RemotePeer { id: string; stream: MediaStream | null; }
+```
+
+### The status signal
+
+```typescript
+type CallStatus = 'idle' | 'connecting' | 'connected' | 'closed';
+```
+
+A live session **starts at `'connecting'`**, flips to `'connected'` when a peer connection actually reaches `connected`, and lands on `'closed'` after `leave()`. `'idle'` exists in the type but a live session never emits it -- do not wait for it. And a lone occupant of a room stays at `'connecting'` until someone else joins.
+
+### Binding streams into the DOM
+
+`MediaStream` objects are set on `<video>` elements via the `.srcObject` property. Use an `effect` for the local stream and bind the remote peers in a `mount`:
+
+```typescript
+import { rtc } from 'tina4js/rtc';
+import { html, mount, effect } from 'tina4js';
+
+const call = await rtc.call('standup');
+
+// local preview
+effect(() => {
+  const local = call.localStream.value;
+  if (local) (document.querySelector('#me') as HTMLVideoElement).srcObject = local;
+});
+
+// remote peers -- one <video> each, re-rendered as peers come and go
+mount('#peers', () => html`
+  ${call.peers.value.map(p => html`
+    <video autoplay playsinline .srcObject=${p.stream}></video>
+  `)}
+`);
+```
+
+### Controls
+
+`toggleAudio()` / `toggleVideo()` enable or disable the local track and return the new state (or `false` if there is no such track). Pass an explicit boolean to force it:
+
+```typescript
+call.toggleAudio();       // toggle mic
+call.toggleVideo(false);  // force camera off
+await call.shareScreen(); // getDisplayMedia + swap the outgoing video track
+await call.stopScreen();  // restore the camera track
+```
+
+`shareScreen()` replaces the outgoing video track on the existing peer connections. Clicking the browser's native "Stop sharing" restores the camera automatically.
+
+### Receive-only viewer
+
+Pass `media: false` for a watcher that consumes streams without ever prompting for a camera:
+
+```typescript
+const viewer = await rtc.call('standup', { media: false });
+```
+
+### Leaving
+
+```typescript
+call.leave();
+```
+
+`leave()` is terminal. It sends `bye`, closes every peer connection, **stops your local tracks** (the camera light goes off), closes the signalling socket, and sets `status` to `'closed'`. The session cannot be reused -- call `rtc.call()` again to rejoin.
+
+> **Calls carry no token.** The signalling WebSocket is opened without auth -- there is no `token` option on `rtc.call()`. Secure a private room on the **server** (the signalling route), not from this client. Only `chat` and file operations take a `token`.
+
+---
+
+## 4. Chat -- `rtc.chat(channel, options?)`
+
+A message-and-presence channel over its own WebSocket, backed by a REST history endpoint. It returns **synchronously** -- the socket connects in the background, so watch `session.connected`.
+
+```typescript
+const chat = rtc.chat('general', { token: myJwt });
+```
+
+The `channel` argument accepts a `string` or a `number`.
+
+### `ChatOptions`
+
+| Option | Type | Default | Behaviour |
+|---|---|---|---|
+| `token` | `string` | -- | JWT for the secured chat WS **and** the history calls (bearer on the WS, `Authorization` header on HTTP). |
+| `url` | `string` | `'/ws/chat'` | Explicit WS base; `{channel}` is filled or appended. |
+| `apiBase` | `string` | `''` (same origin) | HTTP base for history. |
+| `messagesPath` | `string` | `'/api/channels/{id}/messages'` | History path template; `{id}` → channel. |
+| `typingTimeout` | `number` | `3000` | ms a typing indicator lingers before auto-clearing. |
+
+### `ChatSession`
+
+```typescript
+interface ChatSession {
+  readonly status: Signal<SocketStatus>;    // 'connecting' | 'open' | 'closed' | 'reconnecting'
+  readonly connected: Signal<boolean>;
+  readonly messages: Signal<ChatMessage[]>; // live + prepended history
+  readonly presence: Signal<string[]>;      // user ids currently in the channel
+  readonly typing: Signal<string[]>;        // user ids currently typing (auto-expire)
+  send(body: string, threadId?: number): void;
+  sendTyping(): void;
+  markRead(): void;
+  history(before?: number, limit?: number): Promise<ChatMessage[]>;
+  close(): void;
+}
+
+interface ChatMessage {
+  id?: number;
+  channel_id?: number;
+  user_id?: string;
+  body?: string;
+  thread_id?: number | null;
+  created_at?: string;
+}
+```
+
+`status` and `connected` are the very same signals from the underlying WebSocket client (Chapter 7) -- reconnection and backoff come along for free.
+
+### A minimal chat panel
+
+```typescript
+import { rtc } from 'tina4js/rtc';
+import { html, mount } from 'tina4js';
+
+const chat = rtc.chat('general', { token: myJwt });
+
+await chat.history();        // load the last 50, prepended into chat.messages
+
+mount('#log', () => html`
+  ${chat.messages.value.map(m => html`<p><b>${m.user_id}</b> ${m.body}</p>`)}
+`);
+
+mount('#who', () => html`Online: ${chat.presence.value.join(', ')}`);
+mount('#typing', () => html`
+  ${chat.typing.value.length ? `${chat.typing.value.join(', ')} typing…` : ''}
+`);
+
+const input = document.querySelector('#msg') as HTMLInputElement;
+input.addEventListener('input', () => chat.sendTyping());
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && input.value) { chat.send(input.value); input.value = ''; }
+});
+```
+
+### Sending, typing, and read receipts
+
+```typescript
+chat.send('hello everyone');       // a top-level message
+chat.send('in reply', 42);         // reply into thread_id 42
+chat.sendTyping();                 // emit a typing signal
+chat.markRead();                   // emit a read receipt
+```
+
+### Paging older messages
+
+`history()` both **prepends** the fetched (older) messages into the `messages` signal **and** returns the raw rows (newest-first). Render from the signal; do not also append the return value or you will duplicate every message. To load an earlier page, pass the oldest id you already hold as `before`:
+
+```typescript
+const oldest = chat.messages.value[0]?.id;
+await chat.history(oldest, 50);
+```
+
+### Teardown
+
+```typescript
+chat.close();   // clears typing timers and closes the socket
+```
+
+> **Read receipts are broadcast but not surfaced.** `markRead()` sends a `read` event and the server rebroadcasts it, but `ChatSession` does not expose the raw socket, so there is no built-in signal for **incoming** read receipts through the returned API.
+
+---
+
+## 5. Files -- `rtc.upload` and `rtc.fetchBlob`
+
+### Uploading
+
+`rtc.upload()` POSTs a `multipart/form-data` body (`channel_id` + `file`) to the files path and resolves with the stored record:
+
+```typescript
+const res = await rtc.upload('general', fileInput.files![0], { token: myJwt });
+// res: UploadResult
+```
+
+```typescript
+interface UploadResult {
+  id: number;
+  key: string;
+  filename: string;
+  mime: string;
+  size: number;
+  url: string;   // presigned URL for S3 backends; a route path for local storage
+}
+
+interface FileOptions {
+  token?: string;
+  apiBase?: string;     // default '' (same origin)
+  filesPath?: string;   // default '/api/files'
+}
+```
+
+### Fetching (permissioned downloads)
+
+A secured GET route cannot be reached by a bare `<img src>` -- there is no way to attach a bearer header to it. `rtc.fetchBlob()` fetches the file **with the auth header** and hands back an object URL you can drop straight into `<img src>` or `<a href>`:
+
+```typescript
+const src = await rtc.fetchBlob(res.key, { token: myJwt });
+imgEl.src = src;
+```
+
+For an S3 backend, `UploadResult.url` is already a presigned URL -- pass it to `fetchBlob` (it is used directly) or set it as `src` without a fetch at all.
+
+> **Object URLs must be revoked.** `fetchBlob()` returns a `URL.createObjectURL(...)` handle. It leaks until you release it -- call `URL.revokeObjectURL(src)` when the element unmounts or the image is no longer needed.
+
+```typescript
+URL.revokeObjectURL(src);
+```
+
+---
+
+## 6. Real Example: A Call + Chat Room
+
+One room. Video down the side, chat down the middle, a file drop at the bottom. Every piece of live state -- peers, messages, presence, connection status -- is a signal, so the template renders itself as the world changes. Nothing here polls.
+
+```typescript
+import { rtc } from 'tina4js/rtc';
+import { html, mount, effect, signal } from 'tina4js';
+
+async function room(name: string, token: string) {
+  // Fetch config once, share it with the call.
+  const config = await rtc.config();
+
+  const call = await rtc.call(name, { config });
+  const chat = rtc.chat(name, { token });
+  const draft = signal('');
+
+  await chat.history();
+
+  // local preview
+  effect(() => {
+    const local = call.localStream.value;
+    if (local) (document.querySelector('#me') as HTMLVideoElement).srcObject = local;
+  });
+
+  // remote peers
+  mount('#peers', () => html`
+    ${call.peers.value.map(p => html`
+      <video class="peer" autoplay playsinline .srcObject=${p.stream}></video>
+    `)}
+  `);
+
+  const send = () => {
+    const body = draft.value.trim();
+    if (body) { chat.send(body); draft.value = ''; }
+  };
+
+  const onFile = async (e: Event) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const res = await rtc.upload(name, file, { token });
+    chat.send(`📎 ${res.filename}`);   // announce it in the channel
+  };
+
+  mount('#app', () => html`
+    <div class="room">
+      <header>
+        <span>Call: ${call.status}</span>
+        <span>Chat: ${chat.status}</span>
+        <span>Online: ${chat.presence.value.length}</span>
+      </header>
+
+      <section class="stage">
+        <video id="me" class="me" autoplay playsinline muted></video>
+        <div id="peers"></div>
+      </section>
+
+      <aside class="chat">
+        <div class="log">
+          ${chat.messages.value.map(m => html`
+            <p><b>${m.user_id}</b> ${m.body}</p>
+          `)}
+        </div>
+        <div class="typing">
+          ${chat.typing.value.length ? `${chat.typing.value.join(', ')} typing…` : ''}
+        </div>
+        <form @submit=${(e: Event) => { e.preventDefault(); send(); }}>
+          <input
+            placeholder="Message…"
+            .value=${draft}
+            @input=${(e: Event) => {
+              draft.value = (e.target as HTMLInputElement).value;
+              chat.sendTyping();
+            }}
+          />
+          <button type="submit" ?disabled=${() => !chat.connected.value}>Send</button>
+        </form>
+        <input type="file" @change=${onFile} />
+      </aside>
+
+      <footer>
+        <button @click=${() => call.toggleAudio()}>Mute</button>
+        <button @click=${() => call.toggleVideo()}>Camera</button>
+        <button @click=${() => call.shareScreen()}>Share screen</button>
+        <button @click=${() => { call.leave(); chat.close(); }}>Leave</button>
+      </footer>
+    </div>
+  `);
+}
+
+room('standup', localStorage.getItem('tina4_token') ?? '');
+```
+
+The `#me` video is `muted` on purpose -- it is your own microphone echoing back, and unmuting it causes feedback. Always `leave()` the call and `close()` the chat together on teardown; both release sockets and timers, and `leave()` frees the camera and mic.
+
+---
+
+## 7. Hard Rules
+
+WebRTC has sharp edges. These are the ones the module cannot paper over for you:
+
+1. **`rtc.call()` is async; `rtc.chat()` is sync.** `await` the call, not the chat.
+2. **`rtc.config` is the fetch function, not a config object** -- it is `=== rtcConfig`. Call it: `await rtc.config()`.
+3. **`status` only reaches `'connected'` when a remote peer connects.** A lone occupant stays `'connecting'`, and `'idle'` is never emitted by a live session.
+4. **`leave()` is terminal.** It stops your tracks, closes everything, and cannot be reused. Call `rtc.call()` again to rejoin.
+5. **Calls take no `token`.** Secure a private room on the signalling route server-side.
+6. **`history()` mutates *and* returns.** Render from the `messages` signal; do not also append its return value.
+7. **`fetchBlob()` leaks without cleanup.** Revoke the object URL with `URL.revokeObjectURL()` when done.
+8. **Signals follow the new-reference rule.** Read `peers` / `messages` / `presence` / `typing`; never mutate them in place.
+9. **Always tear down.** `leave()` the call and `close()` the chat to release cameras, sockets, and timers.
+
+---
+
+## 8. Backend Pairing
+
+This module is the front half of a pair. It talks to a Tina4 backend that mounts the realtime module, which serves `GET /api/rtc/config`, relays the signalling WebSocket, brokers the chat channel, and stores files. Nothing here works until that mount is in place -- and the client deliberately learns every path and ICE server from the config endpoint, so the two sides stay in sync without you hardcoding anything.
+
+Wire up the backend in your language of choice:
+
+| Backend | Mount | Guide |
+|---|---|---|
+| Python | `realtime()` | [tina4-python](/python/index.md) |
+| PHP | `realtime()` | [tina4-php](/php/index.md) |
+| Node.js | `realtime()` | [tina4-nodejs](/nodejs/index.md) |
+| Ruby | `Tina4::Realtime.mount` | [tina4-ruby](/ruby/index.md) |
+
+---
+
+## Summary
+
+| What | How |
+|---|---|
+| Import | `import { rtc } from 'tina4js/rtc'` |
+| Fetch config | `await rtc.config(url?)` -- `GET /api/rtc/config` |
+| Start / join a call | `await rtc.call(room, options?)` -- **async** |
+| Local / remote media | `call.localStream` / `call.peers` -- bind to `<video>.srcObject` |
+| Call status | `call.status` -- `'idle' \| 'connecting' \| 'connected' \| 'closed'` |
+| Mic / camera | `call.toggleAudio(on?)` / `call.toggleVideo(on?)` |
+| Screen share | `call.shareScreen()` / `call.stopScreen()` |
+| Leave a call | `call.leave()` -- terminal, releases the camera |
+| Open a chat | `rtc.chat(channel, options?)` -- **sync** |
+| Send a message | `chat.send(body, threadId?)` |
+| Typing / read | `chat.sendTyping()` / `chat.markRead()` |
+| Presence / typing | `chat.presence` / `chat.typing` signals |
+| Load history | `await chat.history(before?, limit?)` -- prepends into `messages` |
+| Close a chat | `chat.close()` |
+| Upload a file | `await rtc.upload(channel, file, options?)` → `UploadResult` |
+| Permissioned download | `await rtc.fetchBlob(keyOrUrl, options?)` → object URL (revoke it) |
+| Backend | Pairs with a Tina4 `realtime()` mount |

--- a/docs/nodejs/38-realtime-webrtc.md
+++ b/docs/nodejs/38-realtime-webrtc.md
@@ -1,0 +1,561 @@
+# Chapter 38: Real-time Collaboration (WebRTC)
+
+## 1. Calls, Chat and Files Without a Media Server
+
+You want a video call, a live chat channel, or a drag-and-drop file share inside your app. The reflex is to reach for a media server -- an SFU, a TURN farm, a third-party SDK, a monthly bill. For a small team or a peer-to-peer session, that is a lot of machinery.
+
+Tina4's `realtime()` mount takes a different path. It ships a **mesh WebRTC signalling relay**: the browsers form direct peer-to-peer connections and stream audio and video to each other. Tina4 never touches the media. It only relays the WebRTC handshake -- the offer, the answer, the ICE candidates -- and it never even parses the SDP. That means no media server to run, no per-minute cost, and zero dependencies for the core feature.
+
+On top of that same mount you can turn on **persistent chat** (channels, messages, presence, typing indicators, read receipts) and **file upload/download** (local disk by default, S3 when you want it). One call, three features, one wire contract the browser discovers for itself.
+
+```typescript
+import { realtime } from "tina4-nodejs/orm";
+
+await realtime({ features: ["calls", "chat", "files"] });
+```
+
+> Mesh is peer-to-peer: every participant connects to every other participant. It is perfect for 1:1 and small-group sessions. For large rooms an SFU is the right tool -- but that is not what ships here (see §11).
+
+---
+
+## 2. What You Get
+
+Enabling `realtime()` wires up to three feature bundles, each guarded appropriately:
+
+| Feature | What it gives you | Transport |
+|---|---|---|
+| `calls` | WebRTC signalling relay (mesh) + a self-describing ICE-config endpoint | Public WebSocket + public `GET` |
+| `chat` | Channels, messages, live presence / typing / read receipts, catch-up history | JWT-secured WebSocket + secured `GET` |
+| `files` | Permissioned upload / download through a pluggable storage backend | Auth-required `POST` + secured `GET` |
+
+The whole surface is exported from the ORM package. Import what you need from `tina4-nodejs/orm`:
+
+```typescript
+import {
+  realtime,           // the mount
+  iceServers,         // build the ICE/TURN list from env
+  selectStorage,      // resolve a storage backend
+  storageKey,         // opaque, collision-free file keys
+  LocalStorage,       // default filesystem store
+  S3Storage,          // opt-in S3-compatible store
+  type RealtimeOptions,
+  type StorageBackend,
+  // framework-owned ORM models (Realtime-prefixed so they never collide with yours)
+  RealtimeWorkspace,
+  RealtimeChannel,
+  RealtimeChannelMember,
+  RealtimeMessage,
+  RealtimeAttachment,
+} from "tina4-nodejs/orm";
+```
+
+Tina4 carries **no media**. It relays the WebRTC offer/answer/ICE frames and gets out of the way; the peers connect directly and filter frames by a `to` field they put in the payload themselves.
+
+> **This is the backend.** The browser client that consumes it -- `getUserMedia`, `RTCPeerConnection`, the chat socket UI -- is your frontend's job. It fetches `/api/rtc/config` and drives the WebSockets described below. The examples in this chapter use plain browser Web APIs so they run anywhere.
+
+---
+
+## 3. Mounting: `await realtime(options?)`
+
+Call `realtime()` **once** in `app.ts`, **before** `startServer()`. It creates the chat tables (when needed), registers the routes, and returns the resolved path map -- which is also served from the config endpoint, so the client discovers every path and never hardcodes a URL.
+
+```typescript
+// app.ts
+import { startServer } from "tina4-nodejs";
+import { initDatabase, realtime } from "tina4-nodejs/orm";
+
+await initDatabase(process.env.TINA4_DATABASE_URL!);   // bind the DB FIRST (see §11)
+
+await realtime();                                          // calls only (default)
+await realtime({ features: ["calls", "chat"] });          // add persistent chat
+await realtime({ prefix: "/api/collab", features: ["calls", "chat", "files"] });
+
+startServer();
+```
+
+> **`realtime()` is `async` in Node -- always `await` it.** Route registration itself is synchronous, but Node's ORM creates the `tina4_rt_*` tables asynchronously, so the mount returns a `Promise`. Awaiting it guarantees the tables exist before the first chat, history, or file request lands. (The Python master's `realtime()` is synchronous; Node's is not -- this is a Node-specific gotcha.)
+
+### `RealtimeOptions`
+
+```typescript
+interface RealtimeOptions {
+  prefix?: string;
+  authorize?: (identity: string, channelId: number) => boolean | Promise<boolean>;
+  storage?: StorageBackend;
+  features?: string[];
+}
+```
+
+| Option | Meaning |
+|---|---|
+| `prefix` | Mounts the whole surface under `/<prefix>` (default: root). Leading/trailing slashes are stripped: `"/api/collab/"` becomes `/api/collab`. |
+| `authorize` | Channel-membership guard, `(identity, channelId) => boolean \| Promise<boolean>` (sync **or** async). Used by `chat` and `files`. Defaults to a `RealtimeChannelMember` membership check. `identity` is the **string** user id taken from the JWT. |
+| `storage` | A `StorageBackend` for the `files` feature. Defaults to the env-selected store (`local`). |
+| `features` | Array of `"calls"`, `"chat"`, `"files"`. **Defaults to `["calls"]`.** |
+
+### What it returns -- the resolved path map
+
+The returned map holds the **base** paths. The config endpoint body adds the `{room}` / `{channel}` / `{id}` template tokens the client fills in.
+
+```typescript
+await realtime();
+// -> { backend: "mesh", config: "/api/rtc/config", signalling: "/ws/rtc" }
+
+await realtime({ features: ["calls", "chat"] });
+// -> { backend, config, signalling: "/ws/rtc", chat: "/ws/chat", messages: "/api/channels" }
+
+await realtime({ features: ["files"] });
+// -> { backend, config, files: "/api/files" }
+```
+
+`config` is added by **any** enabled feature (`calls` sets it; `chat` and `files` add it with `??=`), so even a chat-only or files-only mount still exposes `/api/rtc/config`.
+
+### What each feature wires
+
+| Feature | Routes registered | Auth |
+|---|---|---|
+| any | `GET  {p}/api/rtc/config` | **public** -- no `.secure()` |
+| `calls` | `WS   {p}/ws/rtc/{room}` | **public** -- unauthenticated |
+| `chat` | `WS   {p}/ws/chat/{channel}` | **secured** -- `Router.websocket(..., { secured: true })`, valid JWT required on upgrade |
+| `chat` | `GET  {p}/api/channels/{id}/messages` | `.secure()` |
+| `files` | `POST {p}/api/files` | auth-required (Tina4 secures write routes by default) |
+| `files` | `GET  {p}/api/files/{key}` | `.secure()` |
+
+When `chat` or `files` is enabled, the framework runs `ensureChatTables()` at mount time to create the `tina4_rt_*` tables (see §11).
+
+---
+
+## 4. `GET {p}/api/rtc/config` -- Public Bootstrap
+
+This is the single call the frontend makes on startup. The server describes itself -- ICE servers, WebSocket paths, feature availability -- so the client and server can never drift out of sync. The body is **feature-gated**: only the keys for enabled features appear, and this is where the template tokens live.
+
+```jsonc
+{
+  "backend": "mesh",
+  "iceServers": [ /* result of iceServers() */ ],   // calls
+  "signalling": "/ws/rtc/{room}",                    // calls
+  "chat": "/ws/chat/{channel}",                      // chat
+  "messages": "/api/channels/{id}/messages",         // chat
+  "files": "/api/files"                              // files
+}
+```
+
+Fetch it once, then substitute the tokens:
+
+```js
+const cfg = await fetch("/api/rtc/config").then(r => r.json());
+
+const pc = new RTCPeerConnection({ iceServers: cfg.iceServers });
+const signalling = new WebSocket(
+  location.origin.replace(/^http/, "ws") + cfg.signalling.replace("{room}", roomId)
+);
+```
+
+> This endpoint is **public** and returns your ICE/TURN configuration, including freshly-minted ephemeral TURN credentials. That is by design -- the client needs them before it authenticates -- but be aware anyone can read it.
+
+---
+
+## 5. ICE / TURN Configuration -- `iceServers()`
+
+`iceServers()` is exported so you can inspect or reuse the list. It builds the ICE server array from environment variables:
+
+- It **always** includes a STUN entry.
+- It adds a TURN entry with time-limited coturn `use-auth-secret` credentials **only when both** `TINA4_RTC_TURN_URL` and `TINA4_RTC_TURN_SECRET` are set.
+
+The ephemeral TURN credential scheme matches coturn's REST API:
+
+```
+username   = String(Math.floor(Date.now() / 1000) + ttl)
+credential = base64( HMAC_SHA1(secret, username) )
+```
+
+built with Node's `node:crypto` `createHmac`. The credential expires after `ttl` seconds, so a leaked config from `/api/rtc/config` is only briefly useful.
+
+```jsonc
+// no TURN env set:
+[ { "urls": ["stun:stun.l.google.com:19302"] } ]
+
+// TINA4_RTC_TURN_URL + TINA4_RTC_TURN_SECRET set:
+[ { "urls": ["stun:stun.l.google.com:19302"] },
+  { "urls": ["turn:turn.example.com:3478"], "username": "1783546725", "credential": "ie7Mm...==" } ]
+```
+
+### Environment variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `TINA4_RTC_STUN_URLS` | `stun:stun.l.google.com:19302` | Comma-separated STUN URLs. |
+| `TINA4_RTC_TURN_URL` | — | Comma-separated TURN URLs; enables TURN when set together with the secret. |
+| `TINA4_RTC_TURN_SECRET` | — | coturn `use-auth-secret` shared secret (ephemeral credentials). |
+| `TINA4_RTC_TURN_TTL` | `3600` | Ephemeral TURN credential lifetime, in seconds. |
+
+> `TINA4_RTC_BACKEND` is **not read** in Node. The backend is always `mesh` (see §11).
+
+---
+
+## 6. Signalling WebSocket: `{p}/ws/rtc/{room}` -- Public
+
+Registered by the `calls` feature. This is the WebRTC control channel: browsers send each other their offer, answer, and ICE candidates through it, and Tina4 relays the raw frames. **It is not secured -- anyone can join any room** (see §11).
+
+It uses the standard Tina4 WebSocket handler convention, `(connection, event, data)`:
+
+```typescript
+(connection, event, data) => {
+  // event: "open" | "message" | "close"; data is the string frame on "message"
+};
+```
+
+The mesh relay behaviour is small and deliberate:
+
+- `room = connection.params.room ?? ""`; an empty room is a no-op (the handler returns).
+- On `event === "open"` -> `connection.joinRoom("rtc:" + room)`.
+- On `event === "message"` -> `connection.broadcastToRoom("rtc:" + room, data, true)` -- it relays the **raw** frame to the other peers (`excludeSelf = true`).
+
+Tina4 never inspects the SDP. Peers put a `to` field in their payloads and filter incoming frames themselves. Rooms are namespaced `rtc:<room>` so signalling rooms never collide with chat channels (`chat:<id>`), which share the same WebSocket manager.
+
+The `WebSocketConnection` surface the relay uses (camelCase in Node):
+
+```typescript
+connection.params                                   // { room: "..." }
+connection.auth                                     // verified JWT payload, or null on a public route
+connection.joinRoom(name)
+connection.broadcastToRoom(name, message, excludeSelf)
+connection.getRoomConnections(key)                  // live connections in a room (for presence)
+connection.sendJson(obj)
+connection.close()
+```
+
+A minimal browser peer, framework-agnostic:
+
+```js
+const ws = new WebSocket(signallingUrl);            // ".../ws/rtc/room-42"
+const pc = new RTCPeerConnection({ iceServers: cfg.iceServers });
+
+pc.onicecandidate = (e) => {
+  if (e.candidate) ws.send(JSON.stringify({ to: peerId, type: "ice", candidate: e.candidate }));
+};
+
+ws.onmessage = async (ev) => {
+  const msg = JSON.parse(ev.data);
+  if (msg.to !== myId) return;                      // Tina4 relays to everyone; filter yourself
+  if (msg.type === "offer") {
+    await pc.setRemoteDescription(msg.sdp);
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+    ws.send(JSON.stringify({ to: msg.from, type: "answer", sdp: answer }));
+  } else if (msg.type === "answer") {
+    await pc.setRemoteDescription(msg.sdp);
+  } else if (msg.type === "ice") {
+    await pc.addIceCandidate(msg.candidate);
+  }
+};
+```
+
+---
+
+## 7. Chat WebSocket + History -- Secured
+
+### `{p}/ws/chat/{channel}` -- secured
+
+Registered as `Router.websocket(path, chatHandler, { secured: true })`. A **valid JWT is required on the upgrade** -- an unauthenticated upgrade is rejected (401) before the handler ever runs.
+
+- The channel is addressed by **integer id**: `connection.params.channel` must match `/^\d+$/`. A non-integer channel makes the handler return silently -- the socket opens and does nothing (see §11).
+- `identity` is extracted from `connection.auth` (the verified JWT payload).
+- The room key is `chat:<channelId>`.
+
+All inbound frames are JSON; every broadcast is a `JSON.stringify(...)` string. The handler is **`async`** -- it awaits the membership check and message persistence on each frame.
+
+| Event / message `type` | Server behaviour |
+|---|---|
+| `open` | Authorize. **Fail ->** send `{ type: "error", error: "not a member of this channel" }` then `close()`. **OK ->** `joinRoom`, send the caller the roster `{ type: "presence", event: "roster", users: [...] }`, then broadcast `{ type: "presence", event: "join", user_id }` (excluding self). |
+| `close` | Broadcast `{ type: "presence", event: "leave", user_id }` (excluding self). |
+| message `typing` | Broadcast `{ type: "typing", user_id }` (excluding self). |
+| message `read` | Advance the member's read cursor (`last_read_at = now`), broadcast `{ type: "read", user_id, at: <iso> }` (excluding self). |
+| message `message` | Trim `body`; if empty, **ignore**. Persist a `RealtimeMessage` row; on success broadcast `{ type: "message", message: <saved> }` to **everyone including the sender** (so the sender's optimistic message reconciles with its server `id` and `created_at`). |
+
+- `type` defaults to `"message"` when absent. Unknown `type` values are ignored.
+- The roster is the sorted set of distinct identities currently in the room (read from each live connection's `auth`).
+- **Authorization is re-checked on every inbound frame**, not just on join -- membership can be revoked mid-session, and the server never trusts an identity carried in the payload.
+
+The saved-message JSON shape (also what history returns):
+
+```jsonc
+{ "id": 12, "channel_id": 3, "user_id": "7", "body": "hi",
+  "thread_id": null, "created_at": "2026-07-08T10:00:00Z" }
+```
+
+`thread_id` is `null` for a top-level message, or the parent message's id for a threaded reply.
+
+A minimal browser chat client:
+
+```js
+const chat = new WebSocket(chatUrl + "?token=" + jwt);   // upgrade must carry a valid JWT
+
+chat.onmessage = (ev) => {
+  const m = JSON.parse(ev.data);
+  switch (m.type) {
+    case "presence": /* m.event: "roster" | "join" | "leave" */ break;
+    case "typing":   showTyping(m.user_id); break;
+    case "read":     advanceReadReceipt(m.user_id, m.at); break;
+    case "message":  appendMessage(m.message); break;   // includes the server id + created_at
+    case "error":    console.warn(m.error); break;
+  }
+};
+
+// send a message
+chat.send(JSON.stringify({ type: "message", body: "hello" }));
+// or a threaded reply
+chat.send(JSON.stringify({ type: "message", body: "re:", thread_id: 12 }));
+// typing indicator / read receipt
+chat.send(JSON.stringify({ type: "typing" }));
+chat.send(JSON.stringify({ type: "read" }));
+```
+
+### `GET {p}/api/channels/{id}/messages` -- `.secure()`
+
+The catch-up-on-reconnect endpoint.
+
+- Identity comes from **`req.user`** (the verified JWT payload the router attached on the secured route).
+- Invalid channel id -> `400 { "error": "invalid channel id" }`; not authorized -> `403 { "error": "forbidden" }`.
+- Query params: `before` (return messages with `id < before`) and `limit` (default **50**, clamped to **1–200**).
+- Returns messages **newest-first** -- the standard infinite-scroll-backwards shape. Each item uses the saved-message JSON shape above.
+
+```js
+// initial load
+let page = await fetch(`/api/channels/3/messages?limit=50`,
+                       { headers: { Authorization: `Bearer ${jwt}` } }).then(r => r.json());
+
+// scroll back: pass the oldest id you have as `before`
+const older = await fetch(`/api/channels/3/messages?before=${page.at(-1).id}&limit=50`,
+                          { headers: { Authorization: `Bearer ${jwt}` } }).then(r => r.json());
+```
+
+---
+
+## 8. Files: Upload / Download
+
+Enable by adding `"files"` to `features`. Uploads flow through a `StorageBackend` -- the `storage` option, or the env-selected store (default `LocalStorage`).
+
+### `POST {p}/api/files` -- upload (auth-required)
+
+- Multipart: a file field named **`file`** (`req.files.file`), plus a form field **`channel_id`** (required integer -- read from body, query, or params).
+- Missing / invalid `channel_id` -> `400 { "error": "channel_id is required" }`; not a channel member -> `403 { "error": "forbidden" }`; no file -> `400 { "error": "no file uploaded (field 'file')" }`.
+- Stores the blob under an opaque, collision-free `storageKey` (16 random bytes hex + a sanitized extension -- **never** a user-controlled path), inserts a `RealtimeAttachment` row (metadata only), and responds **`201`**:
+
+```jsonc
+{ "id": 4, "key": "<storageKey>", "filename": "report.pdf", "mime": "application/pdf",
+  "size": 20481, "url": "<direct url OR {files}/{key}>" }
+```
+
+`url` is `store.url(key)` when the backend exposes a direct URL (for example an S3 presigned link), otherwise the app download route `{files}/{key}`.
+
+```js
+const fd = new FormData();
+fd.append("file", fileInput.files[0]);
+fd.append("channel_id", "3");
+
+const att = await fetch("/api/files", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${jwt}` },      // POST is auth-required
+  body: fd,
+}).then(r => r.json());
+// att.url is either a direct (presigned) URL or /api/files/<key>
+```
+
+### `GET {p}/api/files/{key}` -- download (`.secure()`)
+
+- Looks up the `RealtimeAttachment` by `storage_key`; missing -> `404 { "error": "not found" }`.
+- Authorizes against the attachment's `channel_id`; a non-member gets `403`.
+- If the backend has a direct URL -> **`302`** redirect (`res.redirect(url, 302)`). Otherwise it **streams the bytes** (`200`) with `Content-Disposition: inline; filename="..."` and the attachment's `mime` (default `application/octet-stream`). Missing bytes -> `404`.
+
+### Storage backends (`storage.ts`)
+
+`selectStorage(storage?)` resolves from the `storage` argument or `TINA4_STORAGE_BACKEND` (`local` default | `s3`). An `s3` backend that cannot be built (the **`@aws-sdk/client-s3`** driver missing, or config incomplete) **falls back to `LocalStorage`** with a warning -- a real store, never a silent no-op.
+
+> **Node uses `@aws-sdk/client-s3` (plus `@aws-sdk/s3-request-presigner`), not boto3.** They are optional peer dependencies, loaded lazily. Install them only when you set `TINA4_STORAGE_BACKEND=s3`.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `TINA4_STORAGE_BACKEND` | `local` | `local` \| `s3`. |
+| `TINA4_STORAGE_DIR` | `data/rt_storage` | Local filesystem directory. |
+| `TINA4_STORAGE_URL` | — | S3 endpoint URL (S3-compatible / MinIO); `forcePathStyle: true`. |
+| `TINA4_STORAGE_KEY` / `TINA4_STORAGE_SECRET` | — | S3 credentials. |
+| `TINA4_STORAGE_BUCKET` | — | S3 bucket. Required for S3 -- missing means the constructor throws and selection falls back to local. |
+| `TINA4_STORAGE_REGION` | `us-east-1` | S3 region. |
+
+`LocalStorage` resolves every key inside its root and rejects path traversal; its `url()` returns `null` (files are served by the permissioned download route). `S3Storage.url()` returns a presigned GET URL (default TTL 3600s), so clients fetch large blobs straight from object storage. You can also pass an instance explicitly:
+
+```typescript
+import { realtime, S3Storage } from "tina4-nodejs/orm";
+
+await realtime({
+  features: ["chat", "files"],
+  storage: new S3Storage({ bucket: "collab-files", region: "eu-west-1" }),
+});
+```
+
+---
+
+## 9. Auth & Identity / Channel Membership
+
+Identity is always taken from the **verified token**, never from a message payload.
+
+- **`identityOf(auth)`** extracts a stable **string** user id from a verified JWT payload, trying the claims **`user_id` -> `sub` -> `id`** in order; it returns `null` if none are present. Because identities round-trip as strings, an integer id, a UUID, or an email all work.
+- **WebSocket identity** comes from `connection.auth` (the payload the router attached on the secured upgrade). **HTTP identity** comes from **`req.user`** inside each handler. This is the Node/PHP convention -- the router validates the JWT on the secured / auth-required route and attaches the payload for you.
+- **Default authorization** requires channel membership: `RealtimeChannelMember.count("channel_id = ? AND user_id = ?", [channelId, identity]) > 0`. Any exception is logged and denies (`false`).
+- **A custom `authorize` overrides it** -- `(identity, channelId) => boolean | Promise<boolean>` (sync or async; a promise is awaited). Use it to, say, open public channels to any authenticated user. It short-circuits to `false` when `identity` is `null`, so an unauthenticated caller is always denied. **It runs on every inbound chat frame -- keep it cheap.**
+
+```typescript
+await realtime({
+  features: ["chat"],
+  // any authenticated user may read/write any channel
+  authorize: (_identity, _channelId) => true,
+});
+```
+
+### The data model
+
+Framework-owned `BaseModel` classes, all with the **`tina4_rt_`** table prefix so they never collide with your own tables. They are created on demand at mount via `ensureChatTables()`, in dependency order: `Workspace, Channel, ChannelMember, Message, Attachment`.
+
+| Model (public alias) | Table | Key fields |
+|---|---|---|
+| `RealtimeWorkspace` | `tina4_rt_workspaces` | `id`, `name`, `created_at` |
+| `RealtimeChannel` | `tina4_rt_channels` | `id`, `workspace_id`, `name`, `kind` (`public` \| `private` \| `dm`, default `public`), `created_at` |
+| `RealtimeChannelMember` | `tina4_rt_channel_members` | `id`, `channel_id`, `user_id` (string, ≤128), `role` (default `member`), `last_read_at` (read cursor) |
+| `RealtimeMessage` | `tina4_rt_messages` | `id`, `channel_id`, `user_id` (string), `body` (text), `thread_id` (nullable parent id), `created_at`, `edited_at` (nullable) |
+| `RealtimeAttachment` | `tina4_rt_attachments` | `id`, `channel_id`, `message_id` (nullable), `storage_key`, `filename`, `mime`, `size`, `thumb_key` (nullable) |
+
+`user_id` is a **string** everywhere, so any JWT identity shape fits. Create channels and memberships with these models (or your own admin flow) **before** clients connect -- the mount seeds no data:
+
+```typescript
+import { RealtimeChannel, RealtimeChannelMember } from "tina4-nodejs/orm";
+
+const general = new RealtimeChannel({ workspace_id: 1, name: "general", kind: "public" });
+await general.save();
+
+await new RealtimeChannelMember({
+  channel_id: (general as { id: number }).id,
+  user_id: "7",
+  role: "member",
+}).save();
+```
+
+---
+
+## 10. Complete End-to-End Example
+
+A runnable server with all three features, a seeded channel, and a custom authorize guard.
+
+```typescript
+// app.ts
+import { startServer } from "tina4-nodejs";
+import {
+  initDatabase,
+  realtime,
+  RealtimeChannel,
+  RealtimeChannelMember,
+} from "tina4-nodejs/orm";
+
+// 1. Bind a database FIRST — the chat/files tables are created at mount.
+await initDatabase(process.env.TINA4_DATABASE_URL ?? "sqlite://./data/app.db");
+
+// 2. Mount the realtime surface (await it — it is async in Node).
+const paths = await realtime({
+  prefix: "/api/collab",
+  features: ["calls", "chat", "files"],
+  // Members-only channels: fall back to the default membership check by
+  // returning a promise from the model. (Return `true` here for open channels.)
+  authorize: async (identity, channelId) =>
+    (await RealtimeChannelMember.count(
+      "channel_id = ? AND user_id = ?",
+      [channelId, identity],
+    )) > 0,
+});
+
+console.log(paths);
+// {
+//   backend: "mesh",
+//   config:     "/api/collab/api/rtc/config",
+//   signalling: "/api/collab/ws/rtc",
+//   chat:       "/api/collab/ws/chat",
+//   messages:   "/api/collab/api/channels",
+//   files:      "/api/collab/api/files"
+// }
+
+// 3. Seed a channel + membership so a client can connect (idempotent-ish demo).
+const existing = await RealtimeChannel.where("name = ?", ["general"], 1);
+if (existing.length === 0) {
+  const general = new RealtimeChannel({ workspace_id: 1, name: "general", kind: "public" });
+  await general.save();
+  await new RealtimeChannelMember({
+    channel_id: (general as { id: number }).id,
+    user_id: "7",
+    role: "member",
+  }).save();
+}
+
+// 4. Boot.
+startServer();
+```
+
+```bash
+# run it
+tina4 serve
+```
+
+The browser side, driven entirely by `/api/collab/api/rtc/config`:
+
+```html
+<script type="module">
+  const base = "/api/collab";
+  const jwt = localStorage.getItem("token");        // minted by your login route
+
+  // Discover everything from the server — never hardcode paths.
+  const cfg = await fetch(`${base}/api/rtc/config`).then(r => r.json());
+  const wsOrigin = location.origin.replace(/^http/, "ws");
+
+  // --- calls: mesh WebRTC signalling ---
+  const signalling = new WebSocket(wsOrigin + cfg.signalling.replace("{room}", "room-42"));
+  const pc = new RTCPeerConnection({ iceServers: cfg.iceServers });
+  const local = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+  local.getTracks().forEach(t => pc.addTrack(t, local));
+  // ...exchange offer/answer/ICE over `signalling`, filtering by a `to` field...
+
+  // --- chat: secured WebSocket (JWT on the upgrade) ---
+  const chat = new WebSocket(wsOrigin + cfg.chat.replace("{channel}", "1") + `?token=${jwt}`);
+  chat.onmessage = (ev) => console.log(JSON.parse(ev.data));   // presence/typing/read/message
+  chat.onopen = () => chat.send(JSON.stringify({ type: "message", body: "hello" }));
+
+  // --- history: catch up on reconnect ---
+  const history = await fetch(
+    cfg.messages.replace("{id}", "1") + "?limit=50",
+    { headers: { Authorization: `Bearer ${jwt}` } },
+  ).then(r => r.json());
+
+  // --- files: upload to the channel ---
+  async function upload(file) {
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("channel_id", "1");
+    return fetch(cfg.files, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${jwt}` },
+      body: fd,
+    }).then(r => r.json());   // -> { id, key, filename, mime, size, url }
+  }
+</script>
+```
+
+---
+
+## 11. Footguns / Hard Rules
+
+- **Bind a database BEFORE `realtime({ features: ["chat" | "files"] })`.** `ensureChatTables()` runs at mount, but a failure (no DB bound) is **caught, logged as an ERROR, and boot continues** -- `realtime` still returns the full path map and registers every route; the failure only resurfaces at query time. Call `initDatabase(url)` / `bindDatabase(db)` first, then `await realtime(...)`.
+- **`realtime()` is async -- always `await` it.** Skipping the `await` risks the first chat / history / file request racing table creation.
+- **The signalling WebSocket (`/ws/rtc/{room}`) is PUBLIC.** It is not secured, so anyone can join any room and receive relayed signalling frames. Only the **chat** WebSocket is JWT-secured. Gate call access at the app layer if you need it.
+- **The config endpoint (`/api/rtc/config`) is PUBLIC** and returns your ICE/TURN config, including freshly-minted ephemeral TURN credentials.
+- **The WebSocket handler signature is `(connection, event, data)`** -- `event` is `"open"` / `"message"` / `"close"`, and `data` is the string frame on `"message"`. This matches the Python master. (The **PHP** port fires `($connection, $data, $event)` -- the order differs there, not here.)
+- **Channels are addressed by integer id.** A non-integer `{channel}` makes the chat handler return silently (no error frame) -- the client sees a socket that opens and does nothing.
+- **Chat authorization is re-checked on every frame,** and identity is always taken from the verified token (`connection.auth` / `req.user`), never from the message payload. A custom `authorize` must be cheap -- it runs on every inbound message.
+- **A message with an empty / whitespace `body` is silently dropped** (no persist, no broadcast). `read` / `typing` / unknown types never persist anything.
+- **The backend is hardcoded `mesh` in Node.** There is no `media` option and `TINA4_RTC_BACKEND` is ignored -- the Python master's `media=` parameter and `mint_join` SFU token do **not** exist in the Node port. Only mesh (peer-to-peer, zero-dependency) ships; an SFU / LiveKit backend is a future drop-in, not a current option.

--- a/docs/php/23-websocket.md
+++ b/docs/php/23-websocket.md
@@ -53,18 +53,18 @@ Define WebSocket handlers with `Router::websocket()`:
 <?php
 use Tina4\Router;
 
-Router::websocket("/ws/echo", function ($connection, $event, $data) {
+Router::websocket("/ws/echo", function ($connection, $data, $event) {
     if ($event === "message") {
         $connection->send("Echo: " . $data);
     }
 });
 ```
 
-The simplest handler. It receives a message and sends it back with "Echo: " prepended. Three arguments arrive:
+The simplest handler. It receives a message and sends it back with "Echo: " prepended. Three arguments arrive, **in this order** — the payload comes before the event type:
 
 - **$connection**: The WebSocket connection object. Send messages through it.
+- **$data**: The message payload — the string for `"message"` events, `null` for `"open"` and `"close"`.
 - **$event**: The event type: `"open"`, `"message"`, or `"close"`.
-- **$data**: The message data. Present only for `"message"` events.
 
 ### Starting the Server
 
@@ -97,7 +97,7 @@ Fires when a client connects:
 <?php
 use Tina4\Router;
 
-Router::websocket("/ws/notifications", function ($connection, $event, $data) {
+Router::websocket("/ws/notifications", function ($connection, $data, $event) {
     if ($event === "open") {
         error_log("Client connected: " . $connection->id);
         $connection->send(json_encode([
@@ -114,7 +114,7 @@ Router::websocket("/ws/notifications", function ($connection, $event, $data) {
 Fires when a client sends data:
 
 ```php
-Router::websocket("/ws/notifications", function ($connection, $event, $data) {
+Router::websocket("/ws/notifications", function ($connection, $data, $event) {
     if ($event === "open") {
         $connection->send(json_encode([
             "type" => "welcome",
@@ -142,7 +142,7 @@ Router::websocket("/ws/notifications", function ($connection, $event, $data) {
 Fires when a client disconnects:
 
 ```php
-Router::websocket("/ws/notifications", function ($connection, $event, $data) {
+Router::websocket("/ws/notifications", function ($connection, $data, $event) {
     if ($event === "open") {
         error_log("Client connected: " . $connection->id);
     }
@@ -166,7 +166,7 @@ All three events in one handler:
 <?php
 use Tina4\Router;
 
-Router::websocket("/ws/chat", function ($connection, $event, $data) {
+Router::websocket("/ws/chat", function ($connection, $data, $event) {
     switch ($event) {
         case "open":
             error_log("[Chat] New connection: " . $connection->id);
@@ -204,7 +204,7 @@ Router::websocket("/ws/chat", function ($connection, $event, $data) {
 `$connection->send()` targets the specific client that triggered the event:
 
 ```php
-Router::websocket("/ws/private", function ($connection, $event, $data) {
+Router::websocket("/ws/private", function ($connection, $data, $event) {
     if ($event === "message") {
         $message = json_decode($data, true);
         $action = $message["action"] ?? "";
@@ -236,7 +236,7 @@ Only the sender receives the response. Other connected clients see nothing.
 `$connection->close()` terminates the connection from the server side:
 
 ```php
-Router::websocket("/ws/secure", function ($connection, $event, $data) {
+Router::websocket("/ws/secure", function ($connection, $data, $event) {
     if ($event === "open") {
         // Reject unauthenticated connections
         $token = $connection->params["token"] ?? "";
@@ -264,7 +264,7 @@ The client receives the close event. Use this for kicking users, enforcing authe
 <?php
 use Tina4\Router;
 
-Router::websocket("/ws/announcements", function ($connection, $event, $data) {
+Router::websocket("/ws/announcements", function ($connection, $data, $event) {
     if ($event === "open") {
         // Tell everyone about the new connection
         $connection->broadcast(json_encode([
@@ -334,7 +334,7 @@ Different WebSocket paths are walls. Clients connected to `/ws/chat/room-1` neve
 <?php
 use Tina4\Router;
 
-Router::websocket("/ws/chat/{room}", function ($connection, $event, $data) {
+Router::websocket("/ws/chat/{room}", function ($connection, $data, $event) {
     $room = $connection->params["room"];
 
     if ($event === "open") {
@@ -398,7 +398,7 @@ use Tina4\Router;
 
 $chatUsers = [];
 
-Router::websocket("/ws/livechat/{room}", function ($connection, $event, $data) use (&$chatUsers) {
+Router::websocket("/ws/livechat/{room}", function ($connection, $data, $event) use (&$chatUsers) {
     $room = $connection->params["room"];
 
     if ($event === "open") {
@@ -479,7 +479,7 @@ use Tina4\Router;
 use Tina4\Queue;
 
 // WebSocket handler for notifications
-Router::websocket("/ws/notifications/{userId}", function ($connection, $event, $data) {
+Router::websocket("/ws/notifications/{userId}", function ($connection, $data, $event) {
     $userId = $connection->params["userId"];
 
     if ($event === "open") {
@@ -500,7 +500,7 @@ Router::websocket("/ws/notifications/{userId}", function ($connection, $event, $
 });
 
 // Inside the WebSocket handler, push to everyone on this path
-Router::websocket("/ws/notifications/{userId}", function ($connection, $event, $data) {
+Router::websocket("/ws/notifications/{userId}", function ($connection, $data, $event) {
     if ($event === "message") {
         $payload = json_decode($data, true);
         if (($payload["type"] ?? "") === "order-shipped") {
@@ -770,7 +770,7 @@ use Tina4\Router;
 
 $roomUsers = [];
 
-Router::websocket("/ws/room/{roomName}", function ($connection, $event, $data) use (&$roomUsers) {
+Router::websocket("/ws/room/{roomName}", function ($connection, $data, $event) use (&$roomUsers) {
     $room = $connection->params["roomName"];
     $key = $room . ":" . $connection->id;
 
@@ -950,7 +950,7 @@ Router::websocket("/ws/admin",
     /**
      * @secured
      */
-    function ($connection, $event, $data) {
+    function ($connection, $data, $event) {
         if ($event === "open") {
             // $connection->auth holds the verified token payload.
             $connection->send("Welcome, user {$connection->auth['user_id']}");
@@ -1001,7 +1001,7 @@ Router::websocket("/ws/notifications",
     /**
      * @secured
      */
-    function ($connection, $event, $data) {
+    function ($connection, $data, $event) {
         if ($event === "open") {
             $userId = $connection->auth["user_id"];
             $connection->joinRoom("user-{$userId}");

--- a/docs/php/39-realtime-webrtc.md
+++ b/docs/php/39-realtime-webrtc.md
@@ -1,0 +1,539 @@
+# Chapter 39: Real-time Collaboration (WebRTC)
+
+## 1. Calls, Chat, and Files Without a Media Server
+
+You want video calls, live chat, and file sharing in your app. The usual answer is a media server -- an SFU like LiveKit or Janus -- sitting in the middle, decoding and re-encoding every stream. That is a lot of infrastructure to run, scale, and pay for.
+
+There is a lighter option. Browsers already speak **WebRTC**: they can open direct, encrypted, peer-to-peer connections to each other and stream audio, video, and arbitrary data between themselves. No media server touches the bytes. The catch is that two browsers behind two different NATs cannot find each other on their own. They need a tiny **signalling** channel to swap connection offers, answers, and ICE candidates before the peer-to-peer link comes up.
+
+That signalling channel is the only part that has to live on a server, and it is small. Tina4's realtime module is that server. It relays the WebRTC handshake between peers (a **mesh** -- every peer connects to every other peer), hands the browser its ICE/TURN configuration, and -- when you ask for it -- adds persistent **chat** channels and permissioned **file** upload/download on the same surface.
+
+Tina4 carries **no media**. It relays the offer/answer/ICE frames verbatim and **never parses the SDP**. The framework is the control plane; the browsers are the media plane.
+
+```php
+<?php
+use Tina4\Realtime\Realtime;
+
+Realtime::mount(); // one line: WebRTC signalling is live
+```
+
+> This is a coordinated **cross-language** feature. The routes, JSON shapes, env vars, and the `tina4_rt_*` tables are identical across tina4-python, tina4-php, tina4-ruby, and tina4-nodejs -- only the language changes. If you port an example from the Python or Node docs, read the WebSocket-handler note in [section 6](#_6-calls-the-signalling-relay) first: **PHP fires WebSocket handlers as `($connection, $data, $event)`**, which is a different argument order from the other frameworks.
+
+---
+
+## 2. What You Get
+
+`Realtime::mount()` registers a self-describing surface. You opt into three features:
+
+- **`calls`** (default) -- a public WebRTC signalling relay (`WS /ws/rtc/{room}`) plus a public config endpoint (`GET /api/rtc/config`) that ships the ICE/TURN servers and the paths the client should use.
+- **`chat`** -- a **JWT-secured** WebSocket per channel (`WS /ws/chat/{channel}`) with presence, typing indicators, read receipts, and persisted messages, plus a secured history endpoint (`GET /api/channels/{id}/messages`).
+- **`files`** -- authenticated upload (`POST /api/files`) and secured download (`GET /api/files/{key}`) backed by a pluggable storage backend (local filesystem or S3).
+
+The client never hardcodes a path. It fetches `/api/rtc/config`, reads the paths and ICE servers from the response, and fills in the `{room}` / `{channel}` / `{id}` tokens. Server and client can never drift.
+
+The persistent side (chat + files) is backed by five framework-owned ORM models with a `tina4_rt_` table prefix, so they never collide with your own tables. See [section 11](#_11-the-data-model).
+
+It pairs with the frontend **`tina4-js` `rtc` module** (`rtcConfig()` and the call/chat/file clients), which does the `/api/rtc/config` fetch and token-filling for you. Everything below works with plain browser APIs too.
+
+---
+
+## 3. Mounting the Realtime Surface
+
+```php
+\Tina4\Realtime\Realtime::mount(string $prefix = '', array $options = []): array
+```
+
+Call `mount()` **once in your app bootstrap, before the server starts** -- in `index.php` after `new \Tina4\App()`, or in a `src/` bootstrap file. It registers the routes and **returns the resolved path map** (the same map served from `/api/rtc/config`).
+
+```php
+<?php
+use Tina4\Realtime\Realtime;
+
+Realtime::mount();                                                        // calls only (default)
+Realtime::mount('', ['features' => ['calls', 'chat']]);                   // add persistent chat
+Realtime::mount('/api/collab', ['features' => ['calls','chat','files']]); // relocate the whole surface
+```
+
+### Options
+
+| key | type | meaning |
+|---|---|---|
+| `features` | `string[]` | Any of `"calls"`, `"chat"`, `"files"`. **Default `["calls"]`.** |
+| `authorize` | `callable(string $identity, int $channelId): bool` | Channel-membership guard for `chat`/`files`. Defaults to a `ChannelMember` lookup. `$identity` is the **string** user id from the JWT. |
+| `storage` | `StorageBackend` | Backing store for the `files` feature. Defaults to the env-selected store (`local`). |
+| `media` | object | A media-plane backend. Defaults to the env-selected backend (mesh in Phase 1). |
+
+`$prefix` mounts the entire surface under `/<prefix>` (default: root). It is normalised with `trim($prefix, '/')`, so `'/api/collab'`, `'api/collab'`, and `'api/collab/'` all resolve identically.
+
+### The returned path map
+
+`mount()` returns the **base** paths. The config endpoint appends the template tokens (`/{room}`, `/{channel}`, `/{id}/messages`).
+
+```php
+Realtime::mount();
+// ['backend' => 'mesh', 'config' => '/api/rtc/config', 'signalling' => '/ws/rtc']
+
+Realtime::mount('', ['features' => ['calls', 'chat']]);
+// ['backend' => 'mesh', 'config' => '/api/rtc/config', 'signalling' => '/ws/rtc',
+//  'chat' => '/ws/chat', 'messages' => '/api/channels']
+
+Realtime::mount('', ['features' => ['files']]);
+// ['backend' => 'mesh', 'config' => '/api/rtc/config', 'files' => '/api/files']
+```
+
+`config` is added by **any** enabled feature, so even a chat-only or files-only mount still exposes `/api/rtc/config`.
+
+### What each feature wires
+
+| feature | route registered | auth |
+|---|---|---|
+| any | `GET  {p}/api/rtc/config` | **public** -- `->noAuth()` |
+| `calls` | `WS   {p}/ws/rtc/{room}` | **public** (unauthenticated) |
+| `chat` | `WS   {p}/ws/chat/{channel}` | **secured** -- `Router::websocket(..., secure: true)`; valid JWT required on upgrade |
+| `chat` | `GET  {p}/api/channels/{id}/messages` | **secured** -- `->secure()` |
+| `files` | `POST {p}/api/files` | **auth-required** (write route -- no `->noAuth()`) |
+| `files` | `GET  {p}/api/files/{key}` | **secured** -- `->secure()` |
+
+If `chat` or `files` is enabled, `ensureChatTables()` runs at mount time -- read the [footguns](#_13-footguns-and-hard-rules) about binding a database first.
+
+---
+
+## 4. The Public Bootstrap: `GET /api/rtc/config`
+
+This is the endpoint the frontend fetches so client and server never drift. It is registered with `->noAuth()` -- **public on purpose**, because the client needs it before it can authenticate a call. The body is feature-gated: only keys for enabled features appear.
+
+```jsonc
+{
+  "backend": "mesh",
+  "iceServers": [ /* iceServers() output */ ],  // calls
+  "signalling": "/ws/rtc/{room}",               // calls
+  "chat": "/ws/chat/{channel}",                 // chat
+  "messages": "/api/channels/{id}/messages",    // chat
+  "files": "/api/files"                          // files
+}
+```
+
+`{room}`, `{channel}`, and `{id}` are literal template tokens the client substitutes at connect time:
+
+```js
+const cfg = await fetch("/api/rtc/config").then(r => r.json());
+
+// Join a call room "standup":
+const signalUrl = cfg.signalling.replace("{room}", "standup"); // /ws/rtc/standup
+
+// Open chat channel 42:
+const chatUrl = cfg.chat.replace("{channel}", "42");           // /ws/chat/42
+```
+
+---
+
+## 5. ICE and TURN: `iceServers()` and the Env Vars
+
+```php
+\Tina4\Realtime\Realtime::iceServers(): array
+```
+
+A public static that builds the ICE server list from the environment. It **always** includes a STUN entry. It adds a TURN entry with time-limited coturn `use-auth-secret` credentials **only when both** `TINA4_RTC_TURN_URL` and `TINA4_RTC_TURN_SECRET` are set.
+
+The ephemeral TURN credential scheme (verified against the source):
+
+```php
+$username   = (string)(time() + $ttl);
+$credential = base64_encode(hash_hmac('sha1', $username, $secret, true));
+```
+
+```php
+// No TURN env -- STUN only:
+[['urls' => ['stun:stun.l.google.com:19302']]]
+
+// TINA4_RTC_TURN_URL + TINA4_RTC_TURN_SECRET set:
+[
+  ['urls' => ['stun:stun.l.google.com:19302']],
+  ['urls' => ['turn:turn.example.com:3478'], 'username' => '1783546725', 'credential' => 'ie7Mm...=='],
+]
+```
+
+STUN gets most peers connected; TURN is the relay-of-last-resort for peers behind symmetric NATs that STUN cannot punch through. Because TURN credentials are minted fresh on every `/api/rtc/config` call and expire after `TINA4_RTC_TURN_TTL` seconds, you never ship a long-lived TURN secret to the browser.
+
+### Env vars
+
+| var | default | effect |
+|---|---|---|
+| `TINA4_RTC_BACKEND` | `mesh` | Media backend name. Only `mesh` ships in Phase 1. **The reported `backend` is hardcoded to `mesh` regardless of this value.** |
+| `TINA4_RTC_STUN_URLS` | `stun:stun.l.google.com:19302` | Comma-separated STUN URLs. |
+| `TINA4_RTC_TURN_URL` | -- | Comma-separated TURN URLs; enables TURN when set together with the secret. |
+| `TINA4_RTC_TURN_SECRET` | -- | coturn `use-auth-secret` shared secret (used to sign ephemeral creds). |
+| `TINA4_RTC_TURN_TTL` | `3600` | Ephemeral TURN credential lifetime, in seconds. |
+
+---
+
+## 6. Calls: the Signalling Relay
+
+```
+WS {p}/ws/rtc/{room}   (public)
+```
+
+Registered **unauthenticated** -- there is no `secure:` flag. The handler follows the **PHP WebSocket handler convention**, which is where PHP differs from the other frameworks:
+
+```php
+Router::websocket($paths['signalling'] . '/{room}', function ($connection, $data, $event) {
+    // $connection : the WebSocketConnection
+    // $data       : the payload  -- a string on "message", null on "open"/"close"
+    // $event       : "open" | "message" | "close"
+});
+```
+
+> **PHP argument order is `($connection, $data, $event)`.** The built-in server fires every WebSocket handler positionally as `($connection, null, 'open')`, `($connection, $payload, 'message')`, and `($connection, null, 'close')`. So position 2 is always the **payload** and position 3 is always the **event string**. Python and Node fire `(connection, event, data)`. Name the parameters in the PHP order or `$event` will hold your payload and nothing will work.
+
+The relay logic is deliberately tiny:
+
+- It reads `$room = $connection->params['room'] ?? '';`. An empty room is a no-op.
+- On `open`, the peer joins the room: `$connection->joinRoom("rtc:{$room}")`.
+- On `message`, it relays the **raw** payload to the other peers and excludes the sender: `$connection->broadcastToRoom("rtc:{$room}", (string)$data, true)`. Tina4 never inspects the payload -- peers put a `to` field in their own messages and filter for themselves.
+
+Rooms are namespaced `rtc:<room>` so signalling rooms can never collide with chat channels (`chat:<channel>`) that share the same WebSocket manager.
+
+### The connection surface
+
+Every realtime handler works through these `WebSocketConnection` methods (all **camelCase** in PHP):
+
+| member | purpose |
+|---|---|
+| `$connection->params` | route params, e.g. `['room' => '...']` / `['channel' => '...']` |
+| `$connection->auth` | the verified JWT payload on a **secured** socket (`null` on a public one) |
+| `$connection->joinRoom($name)` | add this connection to a broadcast room |
+| `$connection->broadcastToRoom($name, $message, $excludeSelf = true)` | send a string to a room |
+| `$connection->sendJson($data)` | JSON-encode and send to this one connection |
+| `$connection->getRoomConnections($name)` | the live connections in a room |
+| `$connection->close()` | close this connection |
+
+A minimal browser peer, driven entirely by the config response:
+
+```js
+const cfg  = await fetch("/api/rtc/config").then(r => r.json());
+const room = "standup";
+const ws   = new WebSocket((location.origin.replace(/^http/, "ws")) +
+                           cfg.signalling.replace("{room}", room));
+
+const pc = new RTCPeerConnection({ iceServers: cfg.iceServers });
+
+// Relay ICE candidates to the other peers.
+pc.onicecandidate = (e) => {
+  if (e.candidate) ws.send(JSON.stringify({ type: "ice", candidate: e.candidate }));
+};
+
+ws.onmessage = async (evt) => {
+  const msg = JSON.parse(evt.data);        // raw frame relayed by the server
+  if (msg.type === "offer") {
+    await pc.setRemoteDescription(msg.sdp);
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+    ws.send(JSON.stringify({ type: "answer", sdp: answer }));
+  } else if (msg.type === "answer") {
+    await pc.setRemoteDescription(msg.sdp);
+  } else if (msg.type === "ice") {
+    await pc.addIceCandidate(msg.candidate);
+  }
+};
+```
+
+---
+
+## 7. Chat: the Secured Channel Socket
+
+```
+WS {p}/ws/chat/{channel}   (secured -- valid JWT required on upgrade)
+```
+
+Handler `Realtime::chatHandler($connection, $data, $event)`, registered with `Router::websocket(..., secure: true)`. The router requires a valid JWT on the upgrade and rejects an unauthenticated upgrade with a `401` **before** the handler ever runs.
+
+A browser cannot set request headers on `new WebSocket()`, so it passes the token as the **`bearer` subprotocol** (or a `?token=` query param):
+
+```js
+const token = localStorage.getItem("jwt");
+const url   = (location.origin.replace(/^http/, "ws")) + cfg.chat.replace("{channel}", "42");
+
+const ws = new WebSocket(url, ["bearer", token]);   // browser: bearer subprotocol
+// or: new WebSocket(`${url}?token=${token}`)        // query-param fallback
+```
+
+Two rules shape the handler:
+
+- **Channels are addressed by integer id.** If `{channel}` is not all digits, `chatHandler` returns silently (`ctype_digit()`) -- the socket opens and does nothing, with no error frame.
+- **Identity comes only from the verified token** (`$identity = Realtime::identity($connection->auth)`), never from the message payload. The room key is `chat:<channelId>`.
+
+### Event flow
+
+Inbound frames are JSON; broadcasts are `json_encode(...)` strings.
+
+| event / message `type` | server behaviour |
+|---|---|
+| `open` | Authorize. **Fail →** `sendJson(['type'=>'error','error'=>'not a member of this channel'])` then `close()`. **OK →** `joinRoom`, send the caller the roster `{"type":"presence","event":"roster","users":[…]}`, then broadcast `{"type":"presence","event":"join","user_id":<id>}` (excluding self). |
+| `close` | Broadcast `{"type":"presence","event":"leave","user_id":<id>}` (excluding self). |
+| `typing` | Broadcast `{"type":"typing","user_id":<id>}` (excluding self). |
+| `read` | Advance the member's read cursor (`last_read_at = now`), broadcast `{"type":"read","user_id":<id>,"at":<iso>}` (excluding self). |
+| `message` | Trim `body`; empty is ignored. Persist a `Message`, then broadcast `{"type":"message","message":<saved>}` to **everyone including the sender** (so the sender's optimistic message reconciles with its server `id` + `created_at`). |
+
+`type` defaults to `"message"` when absent; unknown types are ignored. **Authorization is re-checked on every inbound frame**, not just on join -- membership can be revoked mid-session, so keep a custom `authorize` cheap.
+
+The `users` roster is the sorted set of distinct identities currently in the room. It is deliberately built as a **list, not array keys** -- PHP would coerce numeric-string keys to ints and send `[1,2]` instead of `["1","2"]`, breaking the client's string comparison.
+
+### Saved-message shape
+
+The same shape is broadcast on `message` and returned by history:
+
+```jsonc
+{ "id": 128, "channel_id": 42, "user_id": "17", "body": "ship it",
+  "thread_id": null, "created_at": "2026-07-08T09:14:22Z" }
+```
+
+`thread_id` is `null` for a top-level message, or the parent message id for a threaded reply.
+
+---
+
+## 8. Chat History: `GET /api/channels/{id}/messages`
+
+```
+GET {p}/api/channels/{id}/messages   (secured -- ->secure())
+```
+
+The catch-up-on-reconnect endpoint. Load history over HTTP, then keep up over the socket.
+
+- Identity comes from `$request->user` (the router-attached, already-verified JWT payload). Not a member → `403`.
+- Query params: `before` (return messages with `id < before`) and `limit` (default **50**, clamped to **1..200**).
+- Messages come back **newest-first** (`ORDER BY id DESC`), the standard infinite-scroll-backwards shape. Each item uses the saved-message shape above.
+
+```bash
+curl -H "Authorization: Bearer $JWT" \
+  "http://localhost:7145/api/channels/42/messages?limit=50"
+
+# Older page, walking backwards from the oldest id you already have:
+curl -H "Authorization: Bearer $JWT" \
+  "http://localhost:7145/api/channels/42/messages?before=79&limit=50"
+```
+
+---
+
+## 9. Files: Upload, Download, and Storage Backends
+
+Enabled by `features=['files']`. Backed by a `StorageBackend` (the `storage` option, or the env-selected store -- default `LocalStorage`). The backend is resolved once at mount via `Storage::select()`.
+
+### `POST {p}/api/files` -- upload (auth-required)
+
+- Multipart: file field **`file`** (`$request->files['file']`) plus form field **`channel_id`** (required integer, read from body/query/params).
+- Missing/invalid `channel_id` → `400`; not a channel member → `403`; no file → `400`.
+- The blob is stored under an opaque, collision-free `storage_key` (`Storage::key()` -- 16 random bytes as hex plus a sanitized extension, **never a user-controlled path**). An `Attachment` row (metadata only) is inserted, and the response is **`201`**:
+
+```jsonc
+{ "id": 9, "key": "3f9c...b1.png", "filename": "diagram.png",
+  "mime": "image/png", "size": 20481, "url": "<direct url OR {files}/{key}>" }
+```
+
+`url` is `$store->url($key)` when the backend exposes a direct URL (e.g. an S3 presigned GET), otherwise the app download route `{files}/{key}`.
+
+```bash
+curl -H "Authorization: Bearer $JWT" \
+  -F "channel_id=42" \
+  -F "file=@diagram.png" \
+  http://localhost:7145/api/files
+```
+
+### `GET {p}/api/files/{key}` -- download (secured)
+
+- Looks up the `Attachment` by `storage_key`; missing → `404`. Authorizes against the attachment's `channelId`; non-member → `403`.
+- If the backend has a direct URL → **`302`** redirect. Otherwise it **streams the bytes** (`200`) with `Content-Disposition: inline; filename="…"` and `Content-Type = $attachment->mime` (default `application/octet-stream`).
+
+### Storage backends
+
+`Storage::select(?StorageBackend $storage = null)` resolves from the `storage` option or `TINA4_STORAGE_BACKEND` (`local` default | `s3`). `S3Storage` requires the AWS SDK (`aws/aws-sdk-php`); if it cannot be built (SDK missing, or `TINA4_STORAGE_BUCKET` unset) it **falls back to `LocalStorage`** with a logged warning -- a real store, never a silent no-op.
+
+The `StorageBackend` interface:
+
+```php
+interface StorageBackend
+{
+    public function put(string $key, string $data, string $mime): void;
+    public function get(string $key): ?string;
+    public function url(string $key, int $ttl = 3600): ?string;
+    public function delete(string $key): void;
+    public function exists(string $key): bool;
+}
+```
+
+| var | default | effect |
+|---|---|---|
+| `TINA4_STORAGE_BACKEND` | `local` | `local` \| `s3`. |
+| `TINA4_STORAGE_DIR` | `data/rt_storage` | Local filesystem directory. |
+| `TINA4_STORAGE_URL` | -- | S3 endpoint URL (S3-compatible / MinIO → path-style addressing). |
+| `TINA4_STORAGE_KEY` / `TINA4_STORAGE_SECRET` | -- | S3 credentials. |
+| `TINA4_STORAGE_BUCKET` | -- | S3 bucket (required for S3). |
+| `TINA4_STORAGE_REGION` | `us-east-1` | S3 region. |
+
+`LocalStorage` resolves every key inside its root and rejects path traversal (keys containing `/`, `\`, `..`, or NUL); its `url()` returns `null`, so downloads go through the permissioned route. `S3Storage` returns a presigned GET URL from `url()` so clients fetch large blobs straight from object storage.
+
+---
+
+## 10. Auth, Identity, and Channel Membership
+
+- **`Realtime::identity($auth): ?string`** extracts a stable **string** user id from a verified JWT payload array, trying the claims **`user_id` → `sub` → `id`** in order. It returns `null` if `$auth` is not an array or none of those claims are present. Identities round-trip as strings, so an int id, a UUID, or an email all work.
+- **WebSocket identity** comes from `$connection->auth` -- the verified JWT payload the router attached on the secured chat upgrade.
+- **HTTP identity** comes from **`$request->user`** -- the router has already validated the JWT on the secured/auth-required route and exposed its decoded payload there. This is the single source of truth in PHP; do **not** re-parse the `Authorization` header yourself.
+- **Default guard** -- the caller must be a member of the channel:
+  `(new ChannelMember())->count('channel_id = ? AND user_id = ?', [$channelId, $identity]) > 0`. Any exception logs and returns `false` (deny).
+- **`authorize` overrides it** -- pass `authorize(string $identity, int $channelId): bool`. Use it to, for example, open public channels to any authenticated user. An unauthenticated caller (`$identity === null`) is **always denied before the guard runs**, so a custom guard never has to handle a null identity.
+
+```php
+Realtime::mount('', [
+    'features'  => ['calls', 'chat', 'files'],
+    'authorize' => function (string $identity, int $channelId): bool {
+        // Any authenticated user may read/write public channels;
+        // fall back to the default membership check otherwise.
+        $ch = (new \Tina4\Realtime\Channel())->where('id = ?', [$channelId], 1);
+        if (!empty($ch) && $ch[0]->kind === 'public') {
+            return true;
+        }
+        return (new \Tina4\Realtime\ChannelMember())
+            ->count('channel_id = ? AND user_id = ?', [$channelId, $identity]) > 0;
+    },
+]);
+```
+
+---
+
+## 11. The Data Model
+
+Framework-owned ORM models, all with the **`tina4_rt_`** table prefix so they never collide with your own tables. Properties are **camelCase** (Tina4 PHP ORM convention); the ORM maps them to snake_case columns and to snake_case JSON keys, so the schema and wire shape stay byte-identical across every language. `ensureChatTables()` creates them in dependency order: `Workspace, Channel, ChannelMember, Message, Attachment`.
+
+| model | table | key fields (camelCase → wire snake_case) |
+|---|---|---|
+| `Workspace` | `tina4_rt_workspaces` | `id`, `name`, `createdAt` |
+| `Channel` | `tina4_rt_channels` | `id`, `workspaceId`, `name`, `kind` (`public`\|`private`\|`dm`, default `public`), `createdAt` |
+| `ChannelMember` | `tina4_rt_channel_members` | `id`, `channelId`, `userId` (string), `role` (default `member`), `lastReadAt` (read cursor) |
+| `Message` | `tina4_rt_messages` | `id`, `channelId`, `userId` (string), `body`, `threadId` (nullable parent id), `createdAt`, `editedAt` (nullable) |
+| `Attachment` | `tina4_rt_attachments` | `id`, `channelId`, `messageId` (nullable), `storageKey`, `filename`, `mime`, `size`, `thumbKey` (nullable) |
+
+`userId` is a **string** field everywhere so any JWT identity shape (int id, UUID, or email) fits. These are ordinary `\Tina4\ORM` models -- create a channel or add a member the same way you would with any Tina4 model:
+
+```php
+use Tina4\Realtime\Channel;
+use Tina4\Realtime\ChannelMember;
+
+$ch = new Channel();
+$ch->name = "general";
+$ch->kind = "public";
+$ch->save();
+
+$member = new ChannelMember();
+$member->channelId = $ch->id;
+$member->userId    = "17";     // string identity from the JWT
+$member->role      = "member";
+$member->save();
+```
+
+---
+
+## 12. A Complete End-to-End Example
+
+A minimal collaboration backend: calls, chat, and files on one surface, with a public channel policy.
+
+`index.php`:
+
+```php
+<?php
+require_once "vendor/autoload.php";
+
+use Tina4\Realtime\Realtime;
+
+// A bound database MUST exist before mounting chat/files -- see the footguns.
+// Tina4 reads TINA4_DATABASE_URL (or your own init) here.
+$app = new \Tina4\App();
+
+Realtime::mount('', [
+    'features'  => ['calls', 'chat', 'files'],
+    'authorize' => function (string $identity, int $channelId): bool {
+        $ch = (new \Tina4\Realtime\Channel())->where('id = ?', [$channelId], 1);
+        if (!empty($ch) && $ch[0]->kind === 'public') {
+            return true; // any authenticated user may join a public channel
+        }
+        return (new \Tina4\Realtime\ChannelMember())
+            ->count('channel_id = ? AND user_id = ?', [$channelId, $identity]) > 0;
+    },
+]);
+
+$app->run();
+```
+
+Boot it with an STUN/TURN and storage config:
+
+```bash
+export TINA4_DATABASE_URL="sqlite:./data/app.db"
+
+# Calls
+export TINA4_RTC_STUN_URLS="stun:stun.l.google.com:19302"
+export TINA4_RTC_TURN_URL="turn:turn.example.com:3478"
+export TINA4_RTC_TURN_SECRET="a-long-random-coturn-secret"
+export TINA4_RTC_TURN_TTL="3600"
+
+# Files (local by default; switch to s3 with the TINA4_STORAGE_* vars)
+export TINA4_STORAGE_BACKEND="local"
+export TINA4_STORAGE_DIR="./data/rt_storage"
+
+tina4 serve
+```
+
+```
+  Tina4 PHP v3.0.0
+  HTTP server running at http://0.0.0.0:7145
+  WebSocket server running at ws://0.0.0.0:7145
+```
+
+A browser client that bootstraps from config, opens a chat channel, and keeps a call going -- no hardcoded paths:
+
+```js
+const wsBase = location.origin.replace(/^http/, "ws");
+const cfg    = await fetch("/api/rtc/config").then(r => r.json());
+const token  = localStorage.getItem("jwt");
+
+// ── Chat (secured: bearer subprotocol) ──
+const chat = new WebSocket(wsBase + cfg.chat.replace("{channel}", "42"), ["bearer", token]);
+
+chat.onmessage = (evt) => {
+  const m = JSON.parse(evt.data);
+  if (m.type === "presence" && m.event === "roster") console.log("in room:", m.users);
+  if (m.type === "message")                          console.log("msg:", m.message.body);
+};
+chat.onopen = () => chat.send(JSON.stringify({ type: "message", body: "hello team" }));
+
+// ── History (secured HTTP) ──
+const history = await fetch(cfg.messages.replace("{id}", "42") + "?limit=50",
+  { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json());
+
+// ── Call signalling (public) ──
+const signal = new WebSocket(wsBase + cfg.signalling.replace("{room}", "standup"));
+const pc     = new RTCPeerConnection({ iceServers: cfg.iceServers });
+pc.onicecandidate = (e) => e.candidate &&
+  signal.send(JSON.stringify({ type: "ice", candidate: e.candidate }));
+
+// ── File upload (auth-required) ──
+async function upload(file) {
+  const fd = new FormData();
+  fd.append("channel_id", "42");
+  fd.append("file", file);
+  return fetch(cfg.files, { method: "POST", headers: { Authorization: `Bearer ${token}` }, body: fd })
+    .then(r => r.json()); // { id, key, filename, mime, size, url }
+}
+```
+
+---
+
+## 13. Footguns and Hard Rules
+
+- **The WebSocket handler signature is `($connection, $data, $event)`.** `$event` is `"open"` / `"message"` / `"close"`; `$data` is a string on `message` and `null` on `open`/`close`. This is the **PHP** order -- position 2 is the payload, position 3 is the event. Python and Node use `(connection, event, data)`. Get it wrong and your payload lands in `$event`.
+- **Chat needs a bound database -- but a missing one does not crash boot.** With `features=['chat'|'files']`, `ensureChatTables()` runs at mount. If no database is bound it **logs an ERROR and continues**: `mount()` still returns the full path map and registers every route, and the failure only resurfaces at query time. **Bind a database before mounting realtime with chat/files** (`TINA4_DATABASE_URL` or your own DB init) or chat, history, and files will error per-request while the app looks healthy.
+- **The signalling socket (`/ws/rtc/{room}`) is PUBLIC.** It is not `secure:`, so anyone can join any room and receive relayed signalling frames. Only the **chat** socket is JWT-secured. Gate call access at the app layer if you need it.
+- **The config endpoint (`/api/rtc/config`) is PUBLIC** and returns your ICE/TURN config, including freshly-minted ephemeral TURN credentials. That is by design -- the client needs it before it can authenticate -- but do not put secrets in it.
+- **Channels are addressed by integer id.** A non-integer `{channel}` makes `chatHandler` return silently (no error frame) -- the client sees a socket that opens and does nothing.
+- **Chat authorization is re-checked on every frame**, and identity is always taken from the verified token (`$connection->auth` / `$request->user`), never from the message payload. A custom `authorize` must be cheap -- it runs on every inbound message.
+- **A message with an empty or whitespace-only `body` is silently dropped** (no persist, no broadcast). `read` / `typing` / unknown types never persist anything.
+- **`backend` is hardcoded to `'mesh'`** in the path map and config body regardless of `TINA4_RTC_BACKEND` -- a Phase-1 shortcut. Only mesh ships in Phase 1 (browsers connect peer-to-peer). An SFU/LiveKit backend is the documented Phase-2 drop-in with no route changes.
+- **File upload (`POST /api/files`) relies on the framework's default Bearer protection** -- it has no `->noAuth()`, so it is auth-required like any write route. Do not add `->noAuth()` to it.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -197,14 +197,17 @@ whole stack - server, router, ORM, auth, queue, sessions, templating.
 ## Building - use the built-ins, get the exact API (do NOT guess)
 
 Tina4 has 55 built-ins: ORM, Auth (JWT + password hashing), Queue, Sessions,
-Migrations, an `Api` HTTP client, WebSockets, GraphQL, Swagger, CRUD, i18n,
-caching, events, and more. **Use them - never hand-roll what's built in.**
+Migrations, an `Api` HTTP client, WebSockets, real-time collaboration (WebRTC:
+peer calls + chat + files), GraphQL, Swagger, CRUD, i18n, caching, events, and
+more. **Use them - never hand-roll what's built in.**
 
 For exact, version-correct signatures, use these in order - don't invent API
 names:
 
-1. **The installed skills.** `tina4 setup` installs `tina4-developer` and
-   `tina4-js` into `~/.claude/skills`. They are the source of truth for patterns.
+1. **The installed skills.** `tina4 setup` installs the Tina4 skills - the
+   per-language `tina4-developer-<language>` (python/php/ruby/nodejs), `tina4-js`,
+   and `tina4-maintainer` - into `~/.claude/skills`. They are the source of truth
+   for patterns.
 2. **The live project MCP.** A running `tina4 serve` exposes an MCP server at
    `/__dev/mcp` (JSON-RPC) plus a browser REST shim at `/__dev/api/mcp`. Its
    `docs_search`, `project_overview`, `routes`, and `database_*` tools answer

--- a/docs/python/39-realtime-webrtc.md
+++ b/docs/python/39-realtime-webrtc.md
@@ -1,0 +1,524 @@
+# Chapter 39: Real-time Collaboration (WebRTC)
+
+## 1. The Media Server You Don't Have to Run
+
+You want a call button. Two people click it and they are talking — audio, video, a shared screen. Alongside the call there is a chat panel and a place to drop a file. This is the Slack/Teams shape, and the usual advice is to stand up a media server (an SFU like LiveKit or Janus), wire in TURN, and operate all of it.
+
+You do not need any of that to start. Modern browsers already speak WebRTC to each other directly, peer-to-peer. What they cannot do is *find* each other — one browser has to hand its connection offer to the other, and get an answer back. That hand-off is called **signalling**, and it is a tiny amount of text relayed through a server. The media itself — the actual audio and video — never touches your server. It flows browser-to-browser.
+
+Tina4's realtime module is exactly that relay, plus the two things every collaboration tool needs around a call: persistent **chat** and permissioned **file** transfer. It ships in **3.13.57**, has zero extra dependencies, and mounts with one line. Media is peer-to-peer (a **mesh**) by default. Tina4 carries no media and never parses your SDP — it only forwards the handshake. If you outgrow mesh, an SFU backend drops in later with no route changes.
+
+---
+
+## 2. What You Get (and How It Differs from Raw WebSocket)
+
+Chapter 23 gave you the raw `@websocket` primitive: a decorator, a handler, a path. That is the tool you reach for when you are building your *own* protocol. The realtime module is the opposite end — it is a *pre-built* protocol for calls, chat, and files, assembled from that same primitive underneath.
+
+The module gives you three surfaces, and you enable only the ones you want:
+
+- **calls** — a WebRTC **signalling relay** (mesh, peer-to-peer) plus a self-describing ICE-config endpoint. The relay forwards offer/answer/ICE frames between peers in a room. It is **public** — no login to join a room.
+- **chat** — persistent channels and messages backed by framework-owned ORM models, a **secured** chat WebSocket with live presence / typing / read receipts, and a history endpoint for catch-up-on-reconnect.
+- **files** — permissioned upload and download through a pluggable storage backend (local filesystem by default, S3-compatible optional).
+
+The distinction from Chapter 23 in one line:
+
+| Chapter 23 — `@websocket` | Chapter 39 — `realtime()` |
+|---|---|
+| You write the handler and the message protocol | The protocol (signalling, presence, receipts, persistence) is written for you |
+| One path, one decorator, no auth or storage | A whole surface: config endpoint, WS routes, HTTP routes, ORM models, storage |
+| Nothing is persisted unless you persist it | Chat messages and file metadata persist to `tina4_rt_*` tables |
+| You invent the client contract | The client discovers every path from `GET /api/rtc/config` |
+
+Under the hood the realtime WebSockets *are* Tina4 WebSockets — same `(connection, event, data)` handler convention, same room manager. You are just handed the handlers pre-written.
+
+This backend pairs with the frontend **tina4-js `rtc` module**, whose `rtcConfig()` helper fetches the config endpoint so the client and server never drift on paths. Do the backend here; do the browser side in tina4-js (or with the plain browser APIs shown in section 10).
+
+---
+
+## 3. Mounting the Module: `realtime()`
+
+Call `realtime()` once in `app.py`, **before `run()`**. It registers the routes and returns the resolved path map.
+
+```python
+from tina4_python.realtime import realtime
+
+realtime()                                                           # calls only (default)
+realtime(features=["calls", "chat"])                                 # add persistent chat
+realtime(prefix="/api/collab", features=["calls", "chat", "files"])  # relocate the whole surface
+```
+
+The full signature:
+
+```python
+realtime(prefix="", *, media=None, authorize=None, storage=None, features=None) -> dict
+```
+
+| Parameter | Meaning |
+|---|---|
+| `prefix` | Mounts the whole surface under `/<prefix>` (default: root). Internally `prefix.strip("/")`, so `"/api/collab"` and `"api/collab"` behave the same. |
+| `media` | An `RtcMediaBackend`. Defaults to the env-selected backend (`mesh` in Phase 1). Pass one to override the env entirely. |
+| `authorize` | Membership guard `authorize(identity, channel_id) -> bool` (sync **or** async) used by `chat` and `files`. Defaults to a `ChannelMember` check. `identity` is the **string** user id from the JWT. |
+| `storage` | A `StorageBackend` for the `files` feature. Defaults to the env-selected store (`local`). |
+| `features` | List; any of `"calls"`, `"chat"`, `"files"`. **Defaults to `["calls"]`.** |
+
+The call **returns the resolved path map** — the same map the config endpoint serves, so you can log it or assert against it:
+
+```python
+realtime()
+# -> {'backend': 'mesh', 'config': '/api/rtc/config', 'signalling': '/ws/rtc'}
+
+realtime(features=['calls', 'chat'])
+# -> {'backend': 'mesh', 'config': '/api/rtc/config',
+#     'signalling': '/ws/rtc', 'chat': '/ws/chat', 'messages': '/api/channels'}
+
+realtime(prefix='/api/collab', features=['calls', 'chat', 'files'])
+# -> every path prefixed with /api/collab
+```
+
+`config` is added by **any** enabled feature — `calls` sets it outright; `chat` and `files` add it with `setdefault`. So even a chat-only mount exposes `/api/rtc/config`.
+
+### What each feature wires
+
+| Feature | Route registered | Auth |
+|---|---|---|
+| any | `GET  {p}/api/rtc/config` → `rtc_config` | **public** (no auth) |
+| `calls` | `WS   {p}/ws/rtc/{room}` → `rtc_signalling` | **public** (unauthenticated) |
+| `chat` | `WS   {p}/ws/chat/{channel}` → `chat_ws` | **secured** — valid JWT required on upgrade |
+| `chat` | `GET  {p}/api/channels/{id}/messages` → `chat_history` | `auth_required=True` |
+| `files` | `POST {p}/api/files` → `files_upload` | `auth_required=True` |
+| `files` | `GET  {p}/api/files/{key}` → `files_download` | `auth_required=True` |
+
+If `chat` or `files` is enabled, the framework creates its chat tables at mount time (see section 11 — a missing database logs an error but does **not** crash boot).
+
+---
+
+## 4. The Config Bootstrap: `GET /api/rtc/config`
+
+The client never hardcodes a URL. It fetches this one public endpoint, and everything else — the signalling path, the ICE servers, the chat and messages and files paths — comes back in the response. Move `prefix` on the server and the client follows automatically.
+
+The body is **feature-gated**: only keys for enabled features appear.
+
+```jsonc
+{
+  "backend": "mesh",
+  "iceServers": [ /* ...ice_servers()... */ ],   // calls
+  "signalling": "/ws/rtc/{room}",                 // calls
+  "chat": "/ws/chat/{channel}",                   // chat
+  "messages": "/api/channels/{id}/messages",      // chat
+  "files": "/api/files"                            // files
+}
+```
+
+The `{room}` / `{channel}` / `{id}` are **literal template tokens** — the client substitutes the real room name, channel id, or message id before connecting.
+
+This endpoint is **public**, and it returns your ICE/TURN configuration including freshly-minted ephemeral TURN credentials (section 5). That is intentional — the browser needs those before it can authenticate anywhere — but it means the credentials are short-lived by design.
+
+---
+
+## 5. ICE and TURN Servers
+
+Before two browsers can connect, each gathers candidate addresses using **ICE**. A **STUN** server tells a browser its public address; a **TURN** server relays media when a direct path is impossible (strict NAT, symmetric firewalls). The realtime module builds this list from environment variables via `ice_servers()`.
+
+`ice_servers()` **always** includes a STUN entry. It adds a TURN entry **only when both** `TINA4_RTC_TURN_URL` and `TINA4_RTC_TURN_SECRET` are set, using coturn's `use-auth-secret` scheme with time-limited credentials:
+
+- `username = str(int(time.time()) + ttl)` — an expiry epoch.
+- `credential = base64(HMAC_SHA1(secret, username))`.
+
+```python
+# No TURN env — STUN only:
+[{'urls': ['stun:stun.l.google.com:19302']}]
+
+# TINA4_RTC_TURN_URL + TINA4_RTC_TURN_SECRET set:
+[{'urls': ['stun:stun.l.google.com:19302']},
+ {'urls': ['turn:turn.example.com:3478'],
+  'username': '1783546725',
+  'credential': 'ie7Mm...=='}]
+```
+
+### Environment variables
+
+```bash
+# .env
+TINA4_RTC_BACKEND=mesh                          # only 'mesh' ships in Phase 1
+TINA4_RTC_STUN_URLS=stun:stun.l.google.com:19302
+TINA4_RTC_TURN_URL=turn:turn.example.com:3478   # enables TURN when paired with the secret
+TINA4_RTC_TURN_SECRET=your-coturn-shared-secret
+TINA4_RTC_TURN_TTL=3600                          # ephemeral credential lifetime (seconds)
+```
+
+| Var | Default | Effect |
+|---|---|---|
+| `TINA4_RTC_BACKEND` | `mesh` | Media backend name. Only `mesh` ships in Phase 1 — an unknown name falls back to `mesh`, never failing boot. |
+| `TINA4_RTC_STUN_URLS` | `stun:stun.l.google.com:19302` | Comma-separated STUN URLs. |
+| `TINA4_RTC_TURN_URL` | — | Comma-separated TURN URLs; enables TURN when set together with the secret. |
+| `TINA4_RTC_TURN_SECRET` | — | coturn `use-auth-secret` shared secret (drives the ephemeral credentials). |
+| `TINA4_RTC_TURN_TTL` | `3600` | Ephemeral TURN credential lifetime, in seconds. |
+
+### Media backends
+
+The media backend is a strategy object:
+
+- **`RtcMediaBackend`** — the interface. `name = "mesh"`; `mint_join(room, identity)` returns `None` (mesh has no media server to authenticate against); `ice_servers()` delegates to the module-level `ice_servers()`.
+- **`MeshBackend(RtcMediaBackend)`** — the default, zero-dependency backend. Browsers connect peer-to-peer in a mesh.
+- **`_select_backend(media)`** — an explicit `media=` argument wins; otherwise it reads `TINA4_RTC_BACKEND`. **Any unknown name falls back to `MeshBackend`** — it never fails boot.
+
+An SFU/LiveKit backend that returns a real join token is the documented Phase-2 drop-in, and because signalling paths are unchanged, the client keeps working.
+
+---
+
+## 6. Signalling: The Mesh Relay
+
+The signalling handler is registered at `WS {p}/ws/rtc/{room}` and is **public** — anyone can join any room. It follows the framework's WebSocket handler convention (the same as Chapter 23):
+
+```python
+async def rtc_signalling(connection, event, data):
+    # connection : the WebSocketConnection
+    # event      : "open" | "message" | "close"
+    # data       : payload (str for "message", None for "open"/"close")
+    ...
+```
+
+Its behaviour is deliberately minimal — a raw relay:
+
+- Reads `room = connection.params.get("room", "")`. An empty room is a no-op.
+- On `"open"` → `connection.join_room("rtc:<room>")`.
+- On `"message"` → `await connection.broadcast_to_room("rtc:<room>", data, exclude_self=True)` — it forwards the **raw** payload to the other peers in the room, untouched.
+
+Tina4 never parses the SDP. Peers put a `to` field in their own frames and filter for themselves. Rooms are namespaced `rtc:<room>` so signalling rooms never collide with chat channels (which use `chat:<channel>`) on the shared WebSocket manager.
+
+The connection surface these handlers use: `connection.params`, `connection.auth`, `connection.join_room(name)`, `connection.broadcast_to_room(name, message, exclude_self=...)`, `connection.send_json(data)`, and `connection.close()`.
+
+Because signalling is public, the room name is your only barrier. If a call must be private, gate access at your app layer (issue unguessable room ids, or check membership before you hand the client a room name).
+
+---
+
+## 7. Chat: Secured Channels, Presence, History
+
+Chat is the opposite of signalling: **secured**. The handler `chat_ws(connection, event, data)` is marked `chat_ws._secured = True`, so a **valid JWT is required on the WebSocket upgrade** — the router rejects an unauthenticated upgrade before your handler runs.
+
+- Channels are addressed by **integer id**: `int(connection.params["channel"])`. A non-integer `{channel}` makes the handler return silently — the socket opens and does nothing.
+- Identity comes from the verified token: `identity = _identity(connection.auth)` (section 9).
+- The room key is `chat:<channel_id>`.
+
+Every frame is JSON; every broadcast is a `json.dumps(...)` string. The event flow:
+
+| Event / message `type` | Server behaviour |
+|---|---|
+| `open` | Authorize. **Fail →** send `{"type":"error","error":"not a member of this channel"}` then `close()`. **OK →** `join_room`, send the caller the roster `{"type":"presence","event":"roster","users":[...]}`, then broadcast `{"type":"presence","event":"join","user_id":<id>}` (exclude self). |
+| `close` | Broadcast `{"type":"presence","event":"leave","user_id":<id>}` (exclude self). |
+| message `typing` | Broadcast `{"type":"typing","user_id":<id>}` (exclude self). |
+| message `read` | Advance the member's read cursor (`last_read_at = now`), broadcast `{"type":"read","user_id":<id>,"at":<iso>}` (exclude self). |
+| message `message` | Trim `body`; empty → ignored. Persist a `Message` row; on success broadcast `{"type":"message","message":<saved>}` to **everyone including the sender** (so an optimistic client message reconciles with its server `id` + `created_at`). |
+
+`type` defaults to `"message"` when absent. Unknown types are ignored. The roster is the sorted set of distinct identities currently in the room, derived from each live connection's `auth`.
+
+**Authorization is re-checked on every inbound frame**, not just on join — membership can be revoked mid-session, and the server never trusts an identity carried in the payload.
+
+The saved-message JSON shape (also what history returns):
+
+```jsonc
+{ "id": 42, "channel_id": 7, "user_id": "12", "body": "hi team",
+  "thread_id": null, "created_at": "2026-07-08T10:15:00+00:00" }
+```
+
+`thread_id` is `null` for a top-level message, or the parent message id for a threaded reply.
+
+### Chat history: `GET {p}/api/channels/{id}/messages`
+
+A catch-up-on-reconnect endpoint (`auth_required`). Handler `chat_history(request, response)`.
+
+- Identity comes from `authenticate_request(request.headers)`. An invalid channel id → **400**; not authorized → **403**.
+- Query params: `before` (return messages with `id < before`) and `limit` (default **50**, capped at **200**).
+- Returns messages **newest-first** (`ORDER BY id DESC`, applied in SQL) — the standard infinite-scroll-backwards shape. Each item uses the saved-message shape above.
+
+```bash
+curl -H "Authorization: Bearer $JWT" \
+  "http://localhost:7146/api/channels/7/messages?limit=50"
+
+# older page: pass the smallest id you already have as `before`
+curl -H "Authorization: Bearer $JWT" \
+  "http://localhost:7146/api/channels/7/messages?before=42&limit=50"
+```
+
+---
+
+## 8. Files: Upload and Download
+
+Enable with `features=["files"]`. Both routes are `auth_required` and go through a pluggable `StorageBackend` — the `storage=` argument, or the env-selected store (default `LocalStorage`).
+
+### `POST {p}/api/files` — upload
+
+- Multipart: a file field named **`file`**, plus a form field **`channel_id`** (required, integer).
+- Missing/invalid `channel_id` → **400**; not a channel member → **403**; no file → **400**.
+- Stores the blob under an opaque, collision-free `storage_key` (a uuid plus a sanitized extension — never a user-controlled path), inserts an `Attachment` row (metadata only), and responds **201**:
+
+```jsonc
+{ "id": 9, "key": "3f8c...e1.png", "filename": "diagram.png",
+  "mime": "image/png", "size": 20481,
+  "url": "/api/files/3f8c...e1.png" }
+```
+
+`url` is `store.url(key)` when the backend exposes a direct URL (e.g. an S3 presigned URL), otherwise the app download route `{files}/{key}`.
+
+```bash
+curl -X POST http://localhost:7146/api/files \
+  -H "Authorization: Bearer $JWT" \
+  -F "channel_id=7" \
+  -F "file=@diagram.png"
+```
+
+### `GET {p}/api/files/{key}` — download
+
+- Looks up the `Attachment` by `storage_key`; missing → **404**. Authorizes against the attachment's `channel_id`; a non-member → **403**.
+- If the backend has a direct URL → **302** redirect (`Location`). Otherwise it **streams the bytes** (**200**) with `Content-Disposition: inline; filename="…"` and `Content-Type` set from the attachment's `mime` (default `application/octet-stream`).
+
+### Storage backends
+
+`select_storage(storage=None)` resolves from the `storage=` argument or `TINA4_STORAGE_BACKEND`. An `s3` backend that cannot be built (boto3 missing, or incomplete config) **falls back to `LocalStorage`** with a warning — a real store, never a silent no-op.
+
+```bash
+# .env — local (default)
+TINA4_STORAGE_BACKEND=local
+TINA4_STORAGE_DIR=data/rt_storage
+
+# .env — S3-compatible (MinIO, AWS, ...)
+TINA4_STORAGE_BACKEND=s3
+TINA4_STORAGE_URL=https://s3.example.com
+TINA4_STORAGE_KEY=...
+TINA4_STORAGE_SECRET=...
+TINA4_STORAGE_BUCKET=my-bucket
+TINA4_STORAGE_REGION=us-east-1
+```
+
+| Var | Default | Effect |
+|---|---|---|
+| `TINA4_STORAGE_BACKEND` | `local` | `local` \| `s3`. |
+| `TINA4_STORAGE_DIR` | `data/rt_storage` | Local filesystem directory. |
+| `TINA4_STORAGE_URL` | — | S3 endpoint URL (S3-compatible / MinIO). |
+| `TINA4_STORAGE_KEY` / `TINA4_STORAGE_SECRET` | — | S3 credentials. |
+| `TINA4_STORAGE_BUCKET` | — | S3 bucket (required for S3). |
+| `TINA4_STORAGE_REGION` | `us-east-1` | S3 region. |
+
+`LocalStorage` resolves every key inside its root and rejects path traversal; its `url()` returns `None`, so files are served through the permissioned download route. `S3Storage` returns a presigned GET URL from `url()`, so clients fetch large blobs straight from object storage (and downloads become a 302 redirect).
+
+---
+
+## 9. Auth and Identity
+
+Chat and files are membership-gated. Two pieces make that work: how an identity is extracted, and how membership is checked.
+
+**Extracting identity — `_identity(auth)`.** It pulls a stable **string** user id from a verified JWT payload, trying the claims **`user_id` → `sub` → `id`** in order, and returns `None` if `auth` is not a dict or none of those claims are present. Identities round-trip as strings, so an integer id, a UUID, or an email all work:
+
+```python
+_identity({"user_id": 7})    # -> "7"
+_identity({"sub": "abc"})     # -> "abc"
+_identity({"foo": 1})         # -> None
+```
+
+- **WebSocket identity** comes from `connection.auth` — the verified JWT payload the router attached on the secured upgrade.
+- **HTTP identity** comes from `authenticate_request(request.headers)` inside each handler.
+
+**Checking membership — `_default_authorize(identity, channel_id)`.** The secure default: the user must be a member of the channel (`ChannelMember.count("channel_id=? AND user_id=?") > 0`). Any exception logs and returns `False` (deny).
+
+**Overriding it — `authorize=`.** Pass `authorize(identity, channel_id) -> bool`, **sync or async** (a coroutine result is awaited). Use it to, for example, open public channels to any authenticated user. The internal wrapper returns `False` first whenever `identity is None`, so an unauthenticated caller is always denied regardless of your guard.
+
+```python
+# Open every channel to any logged-in user (skip per-channel membership).
+async def allow_any_authenticated(identity, channel_id):
+    return True
+
+realtime(features=["calls", "chat"], authorize=allow_any_authenticated)
+```
+
+Because this runs on **every inbound chat frame**, keep a custom guard cheap.
+
+### Data model
+
+The chat surface persists to framework-owned ORM models, all carrying the **`tina4_rt_`** table prefix so they never collide with your app's tables. `CHAT_MODELS` lists them in dependency order: `[Workspace, Channel, ChannelMember, Message, Attachment]`. Tables are created on demand at mount time.
+
+| Model | Table | Key fields |
+|---|---|---|
+| `Workspace` | `tina4_rt_workspaces` | `id`, `name`, `created_at` |
+| `Channel` | `tina4_rt_channels` | `id`, `workspace_id`→Workspace, `name`, `kind` (`public`\|`private`\|`dm`, default `public`), `created_at` |
+| `ChannelMember` | `tina4_rt_channel_members` | `id`, `channel_id`→Channel, `user_id` (string, ≤128), `role` (`member`\|`admin`\|`owner`, default `member`), `last_read_at` (read cursor) |
+| `Message` | `tina4_rt_messages` | `id`, `channel_id`→Channel, `user_id` (string), `body` (Text), `thread_id` (nullable parent id), `created_at`, `edited_at` (nullable) |
+| `Attachment` | `tina4_rt_attachments` | `id`, `channel_id`→Channel, `message_id`→Message (nullable), `storage_key`, `filename`, `mime`, `size`, `thumb_key` (nullable) |
+
+`user_id` is a **string** everywhere so any JWT identity shape fits. Because these are ordinary Tina4 ORM models, you seed a workspace, a channel, and its members exactly as in Chapter 6:
+
+```python
+from tina4_python.realtime.models import Workspace, Channel, ChannelMember
+
+ws = Workspace(name="Acme")
+ws.save()
+
+channel = Channel(workspace_id=ws.id, name="general", kind="public")
+channel.save()
+
+ChannelMember(channel_id=channel.id, user_id="12", role="owner").save()
+```
+
+Now user `12` can open `WS /ws/chat/{channel.id}` and pass the history and file checks.
+
+---
+
+## 10. A Complete Example
+
+A mesh video call with a chat side-panel, using only the browser's built-in `RTCPeerConnection` and `WebSocket` — no client library required.
+
+### Backend — `app.py`
+
+Mount the surface before `run()`, and seed one channel so chat has somewhere to land.
+
+```python
+from tina4_python import run, bind_database, Database
+from tina4_python.realtime import realtime
+from tina4_python.realtime.models import Workspace, Channel, ChannelMember
+
+# Chat/files need a bound DB BEFORE realtime(features=[...]) — see section 11.
+bind_database(Database("sqlite:data/app.db"))
+
+paths = realtime(features=["calls", "chat", "files"])
+print("realtime mounted:", paths)
+
+# One-time seed so a channel + member exist.
+if not Channel.where("name = ?", ["general"], limit=1):
+    ws = Workspace(name="Acme"); ws.save()
+    channel = Channel(workspace_id=ws.id, name="general", kind="public"); channel.save()
+    ChannelMember(channel_id=channel.id, user_id="12", role="owner").save()
+
+if __name__ == "__main__":
+    run()
+```
+
+### Browser — bootstrap from the config endpoint
+
+The client fetches `/api/rtc/config` first and never hardcodes a path.
+
+```js
+// 1. Discover paths + ICE servers (public endpoint).
+const cfg = await (await fetch("/api/rtc/config")).json();
+
+// 2. Open the signalling socket for a room (public, no token).
+const room = "standup";
+const wsUrl = location.origin.replace(/^http/, "ws")
+            + cfg.signalling.replace("{room}", room);
+const signal = new WebSocket(wsUrl);
+
+// 3. One RTCPeerConnection per call, using the server's ICE list.
+const pc = new RTCPeerConnection({ iceServers: cfg.iceServers });
+
+// Local ICE candidates -> relay to peers through the room.
+pc.onicecandidate = (e) => {
+  if (e.candidate) {
+    signal.send(JSON.stringify({ kind: "ice", candidate: e.candidate }));
+  }
+};
+pc.ontrack = (e) => { document.getElementById("remote").srcObject = e.streams[0]; };
+
+// 4. Handle relayed signalling frames. Tina4 forwards raw payloads verbatim.
+signal.onmessage = async (evt) => {
+  const msg = JSON.parse(evt.data);
+  if (msg.kind === "offer") {
+    await pc.setRemoteDescription(msg.sdp);
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+    signal.send(JSON.stringify({ kind: "answer", sdp: answer }));
+  } else if (msg.kind === "answer") {
+    await pc.setRemoteDescription(msg.sdp);
+  } else if (msg.kind === "ice") {
+    await pc.addIceCandidate(msg.candidate);
+  }
+};
+
+// 5. The caller adds their camera/mic and sends an offer.
+async function startCall() {
+  const media = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+  document.getElementById("local").srcObject = media;
+  media.getTracks().forEach((t) => pc.addTrack(t, media));
+
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  signal.send(JSON.stringify({ kind: "offer", sdp: offer }));
+}
+```
+
+### Browser — the chat side-panel (secured, needs a JWT)
+
+```js
+const channelId = 7;                       // integer id, not a name
+const chatUrl = location.origin.replace(/^http/, "ws")
+              + cfg.chat.replace("{channel}", channelId)
+              + "?token=" + encodeURIComponent(jwt);   // WS carries the JWT
+const chat = new WebSocket(chatUrl);
+
+chat.onmessage = (evt) => {
+  const m = JSON.parse(evt.data);
+  if (m.type === "message")  addLine(m.message.user_id, m.message.body);
+  if (m.type === "presence") renderRoster(m);   // roster / join / leave
+  if (m.type === "typing")   showTyping(m.user_id);
+  if (m.type === "error")    console.warn(m.error);   // e.g. not a member
+};
+
+function send(text) {
+  chat.send(JSON.stringify({ type: "message", body: text }));
+}
+
+// Load the last page of history on open (secured HTTP call).
+const history = await (await fetch(
+  cfg.messages.replace("{id}", channelId) + "?limit=50",
+  { headers: { Authorization: "Bearer " + jwt } }
+)).json();
+```
+
+The signalling socket is public (anyone with the room name joins). The chat socket and the history/file endpoints require a valid JWT and channel membership. Two browser tabs, both members of channel `7`, joined to room `standup`, will see each other's video peer-to-peer and each other's messages through the relay.
+
+---
+
+## 11. Footguns and Hard Rules
+
+### 1. Chat Needs a Bound Database -- But a Missing One Does Not Crash Boot
+
+With `features=["chat"]` or `["files"]`, table creation runs at mount. If **no database is bound**, it **logs an ERROR and continues** -- `realtime()` still returns the full path map and registers every route, and the failure only resurfaces at query time.
+
+**Fix:** Bind a database (`bind_database(db)` or `TINA4_DATABASE_URL`) **before** calling `realtime(features=[...])`, or chat / history / files will error per request while the app looks healthy.
+
+### 2. The Signalling WebSocket Is Public
+
+`/ws/rtc/{room}` is **not** secured. Anyone can join any room and receive the relayed signalling frames. Only the **chat** WebSocket is JWT-secured.
+
+**Fix:** If a call must be private, gate room access at your app layer -- issue unguessable room ids, or check membership before you hand the client a room name.
+
+### 3. The Config Endpoint Is Public
+
+`/api/rtc/config` returns your ICE/TURN configuration, including **freshly-minted ephemeral TURN credentials**. This is by design -- the browser needs them before it can connect -- which is exactly why the TURN credentials are time-limited (`TINA4_RTC_TURN_TTL`).
+
+### 4. The WS Handler Signature Is `(connection, event, data)`
+
+`event` is `"open"` / `"message"` / `"close"`; `data` is a `str` on `"message"` and `None` on `"open"` / `"close"`. This is the framework convention -- **not** `(connection, data, event)`.
+
+### 5. Channels Are Addressed by Integer Id
+
+A non-integer `{channel}` makes the chat handler **return silently** -- no error frame. The client sees a socket that opens and does nothing.
+
+**Fix:** Pass the numeric channel id, never its name.
+
+### 6. Authorization Is Re-Checked on Every Chat Frame
+
+Membership can be revoked mid-session, and identity is always taken from the verified token (`connection.auth` / `authenticate_request`), never from the message payload. A custom `authorize=` must be **cheap** -- it runs on every inbound message.
+
+### 7. Empty Messages Are Silently Dropped
+
+A `message` with an empty or whitespace-only `body` is not persisted and not broadcast. `read` / `typing` / unknown types never persist anything either.
+
+### 8. An Unknown `TINA4_RTC_BACKEND` Silently Falls Back to Mesh
+
+A typo won't error -- you just get `mesh`. Only `mesh` exists in Phase 1, and its `mint_join` returns `None` (there is no SFU join token yet).
+
+---
+
+## Where to Go Next
+
+- **Chapter 23 — WebSocket** — the raw `@websocket` primitive these handlers are built on, and the connection API (`join_room`, `broadcast_to_room`, `send_json`).
+- **Chapter 6 — ORM** and **Chapter 8 — Authentication** — you seed workspaces/channels/members with the ORM, and the JWT that secures chat is the same one from the auth chapter.
+- **tina4-js `rtc` module** — the browser side, whose `rtcConfig()` helper wraps `GET /api/rtc/config` so the client and server never drift.

--- a/docs/ruby/38-realtime-webrtc.md
+++ b/docs/ruby/38-realtime-webrtc.md
@@ -1,0 +1,401 @@
+# Chapter 38: Real-time Collaboration (WebRTC)
+
+## 1. The Media Server You Don't Need to Run
+
+You want a call button. Two people click it and they are talking -- video, audio, a shared screen. Then a chat thread beside the call, with typing indicators and history that survives a reconnect. Then drag-and-drop file sharing into that same channel.
+
+The reflex is to reach for a media server: an SFU, a TURN farm, a signalling service, three moving parts to operate before anyone says a word. `Tina4::Realtime` skips the media server entirely. It ships a **mesh WebRTC control plane** -- Tina4 relays the offer/answer/ICE handshake so two browsers can find each other, and then **the media flows peer-to-peer, end-to-end, never through your server**. Tina4 never sees the audio or video. It never even parses the SDP.
+
+What Tina4 *does* own is everything around the media: a self-describing config endpoint the client bootstraps from, a signalling relay, a secured chat socket with presence and history, and pluggable file storage. Three opt-in features, one `mount` call, zero external dependencies.
+
+Shipped in **tina4-ruby 3.13.57**. This chapter is the backend surface. The browser counterpart is the tina4-js `rtc` module, which fetches `/api/rtc/config` and discovers every path from there -- the client never hardcodes a URL.
+
+---
+
+## 2. What You Get
+
+`Tina4::Realtime` is a zero-dependency real-time control plane with three features you turn on individually:
+
+- **`calls`** -- a WebRTC **signalling relay** (mesh / peer-to-peer) plus a public, self-describing ICE-config endpoint. Media is E2E between the browsers; **Tina4 carries no media -- it only relays the offer/answer/ICE handshake and never inspects the SDP.**
+- **`chat`** -- persistent channels and messages (framework-owned ORM models), a **secured** chat WebSocket with live presence / typing / read receipts, and a history endpoint for catch-up-on-reconnect.
+- **`files`** -- upload/download through a pluggable `StorageBackend` (local filesystem or S3).
+
+Only the features you name are wired. The default is `calls` alone.
+
+**Ruby is mesh-only.** There is a single media backend and `mount` **has no `media:` parameter** -- the path map and the config body both hardcode `"backend" => "mesh"`. (The Python port exposes a `media:` selector for an SFU; Ruby does not yet. An SFU/LiveKit backend is a future drop-in, not a Phase-1 option here.) The `TINA4_RTC_BACKEND` env var exists only for cross-language config parity and is **ignored** in Ruby.
+
+This is a cross-language feature: the same paths, JSON shapes, env vars, and `tina4_rt_*` tables exist in tina4-python, tina4-php, and tina4-nodejs. The Ruby-specific differences are called out in [Footguns](#_11-footguns-hard-rules).
+
+---
+
+## 3. Mounting: `Tina4::Realtime.mount(...)`
+
+Call `mount` once at boot -- in `app.rb`, **after** `Tina4.initialize!` and `Tina4.bind_database`, before the server starts. It registers the routes and WebSockets and **returns the resolved path map** (a Hash with String keys) -- the same map the config endpoint serves back to clients.
+
+```ruby
+Tina4::Realtime.mount(prefix: "", authorize: nil, storage: nil, features: nil)
+```
+
+```ruby
+Tina4::Realtime.mount                                          # calls only (default)
+Tina4::Realtime.mount(features: %w[calls chat])                # add persistent chat
+Tina4::Realtime.mount(prefix: "/api/collab",
+                      features: %w[calls chat files])          # relocate the whole surface
+```
+
+| kwarg | meaning |
+|---|---|
+| `prefix:` | Mounts the whole surface under this path. Leading/trailing slashes are stripped: `"/api/collab"` and `"api/collab/"` both resolve to `/api/collab`. Default `""` (root). |
+| `authorize:` | Membership guard `->(identity, channel_id) { true_or_false }` used by **chat** and **files**. `identity` is the **String** user id from the JWT. Defaults to a `ChannelMember` membership check. |
+| `storage:` | A `StorageBackend` instance for the **files** feature. Defaults to the env-selected store (`local`). |
+| `features:` | Array of any of `"calls"`, `"chat"`, `"files"`. **Default `["calls"]`.** |
+
+**Returns** the resolved path map. Base paths are String-keyed; the config endpoint later appends the `{room}` / `{channel}` / `{id}` template tokens for the client:
+
+```ruby
+Tina4::Realtime.mount
+# => {"backend"=>"mesh", "config"=>"/api/rtc/config", "signalling"=>"/ws/rtc"}
+
+Tina4::Realtime.mount(features: %w[calls chat])
+# => {"backend"=>"mesh", "config"=>"/api/rtc/config", "signalling"=>"/ws/rtc",
+#     "chat"=>"/ws/chat", "messages"=>"/api/channels"}
+
+Tina4::Realtime.mount(features: %w[files])
+# => {"backend"=>"mesh", "config"=>"/api/rtc/config", "files"=>"/api/files"}
+```
+
+`config` is added by **any** enabled feature (`calls` sets it; `chat` and `files` set it with `||=`), so even a chat-only or files-only mount still exposes `/api/rtc/config`.
+
+### What each feature wires
+
+| feature | routes registered | auth |
+|---|---|---|
+| any (has `config`) | `GET  {p}/api/rtc/config` | **public** (no `.secure`) |
+| `calls` | `WS   {p}/ws/rtc/{room}` | **public** (unauthenticated) |
+| `chat` | `WS   {p}/ws/chat/{channel}` | **secured** -- `.secure`, valid JWT required on upgrade |
+| `chat` | `GET  {p}/api/channels/{id}/messages` | **secured** -- `.secure` |
+| `files` | `POST {p}/api/files` (upload) | write route -- default bearer-token gate |
+| `files` | `GET  {p}/api/files/{key}` (download) | **secured** -- `.secure` |
+
+If `chat` or `files` is enabled, `ensure_chat_tables` runs at mount time and creates the `tina4_rt_*` tables. If no database is bound it **logs an error and continues** -- see [Footguns](#_11-footguns-hard-rules).
+
+---
+
+## 4. The Config Bootstrap: `GET {p}/api/rtc/config`
+
+This is the one URL the frontend has to know. It fetches the config, reads back the paths and ICE servers, and drives everything else from there -- client and server never drift because the server is the single source of truth for its own routes.
+
+The body is **feature-gated**: only keys for enabled features appear.
+
+```jsonc
+{
+  "backend": "mesh",
+  "iceServers": [ /* Tina4::Realtime.ice_servers */ ],   // calls
+  "signalling": "/ws/rtc/{room}",                        // calls
+  "chat": "/ws/chat/{channel}",                          // chat
+  "messages": "/api/channels/{id}/messages",             // chat
+  "files": "/api/files"                                  // files
+}
+```
+
+`{room}`, `{channel}`, and `{id}` are literal template tokens the client substitutes. The endpoint is **public** -- no token required -- because the client needs the ICE config before it has authenticated anyone into a call.
+
+```js
+// Browser: discover everything from one fetch, then wire the sockets.
+const cfg = await fetch("/api/rtc/config").then(r => r.json());
+
+const signallingUrl = cfg.signalling.replace("{room}", roomId);   // /ws/rtc/room-42
+const pc = new RTCPeerConnection({ iceServers: cfg.iceServers });
+const ws = new WebSocket(`wss://${location.host}${signallingUrl}`);
+```
+
+---
+
+## 5. ICE / TURN: `Tina4::Realtime.ice_servers`
+
+Peers on the same network find each other with STUN alone. Peers behind symmetric NATs need a TURN relay. `ice_servers` builds the list the client hands to `RTCPeerConnection`, straight from the environment.
+
+It **always** includes a STUN entry. It adds a TURN entry **only when both** `TINA4_RTC_TURN_URL` and `TINA4_RTC_TURN_SECRET` are set. TURN credentials use the coturn **`use-auth-secret`** (ephemeral) scheme -- a time-limited username/credential pair minted on each request, so you never ship static TURN passwords to the browser:
+
+```ruby
+username   = (Time.now.to_i + ttl).to_s                                   # expiry epoch
+credential = Base64.strict_encode64(OpenSSL::HMAC.digest("SHA1", secret, username))
+```
+
+```ruby
+# No TURN env set:
+Tina4::Realtime.ice_servers
+# => [{"urls"=>["stun:stun.l.google.com:19302"]}]
+
+# TINA4_RTC_TURN_URL + TINA4_RTC_TURN_SECRET set:
+# => [{"urls"=>["stun:stun.l.google.com:19302"]},
+#     {"urls"=>["turn:turn.example.com:3478"], "username"=>"1783546725", "credential"=>"ie7Mm...=="}]
+```
+
+STUN and TURN URLs are comma-separated in the env and split into arrays.
+
+### Environment variables
+
+| var | default | effect |
+|---|---|---|
+| `TINA4_RTC_STUN_URLS` | `stun:stun.l.google.com:19302` | Comma-separated STUN URLs. |
+| `TINA4_RTC_TURN_URL` | -- | Comma-separated TURN URLs; enables TURN when set **together with** the secret. |
+| `TINA4_RTC_TURN_SECRET` | -- | coturn `use-auth-secret` shared secret (ephemeral creds). |
+| `TINA4_RTC_TURN_TTL` | `3600` | Ephemeral TURN credential lifetime, in seconds. |
+| `TINA4_RTC_BACKEND` | -- | **Read only for cross-language config parity; Ruby ignores it.** The backend is always `mesh`. |
+
+```bash
+# Enable a coturn relay for peers behind symmetric NAT.
+export TINA4_RTC_TURN_URL="turn:turn.example.com:3478"
+export TINA4_RTC_TURN_SECRET="a-long-random-shared-secret"
+export TINA4_RTC_TURN_TTL="3600"
+```
+
+---
+
+## 6. The Signalling WebSocket (mesh): `WS {p}/ws/rtc/{room}`
+
+This is the relay that lets two browsers negotiate a peer connection. It is registered with `Tina4::Router.websocket(...)` and is **not** `.secure`, so it is **public**. The Ruby WebSocket convention is `(connection, event, data)` where `event` is a **Symbol**:
+
+```ruby
+# connection : the WebSocket connection
+# event      : :open | :message | :close
+# data       : the payload String on :message; nil on :open / :close
+```
+
+The whole handler is a mesh relay -- it moves opaque frames between peers and gets out of the way:
+
+```ruby
+Tina4::Router.websocket "/ws/rtc/{room}" do |connection, event, data|
+  room = connection.params[:room].to_s
+  next if room.empty?                                   # empty room -> no-op
+
+  key = "rtc:#{room}"
+  case event
+  when :open
+    connection.join_room(key)
+  when :message
+    connection.broadcast_to_room(key, data, exclude_self: true)  # relay raw, verbatim
+  end
+end
+```
+
+Behavior:
+
+- `room = connection.params[:room].to_s`; an **empty room is a no-op** (the handler returns).
+- `:open` -- `connection.join_room("rtc:#{room}")`.
+- `:message` -- `connection.broadcast_to_room("rtc:#{room}", data, exclude_self: true)` relays the **raw** payload to the other peers. Tina4 never parses the SDP; peers address each other by putting a `to` field in their own payload and filtering on it.
+
+Rooms are namespaced `rtc:<room>` so signalling rooms never collide with chat channels (`chat:<channel>`) sharing the same WebSocket manager.
+
+Because the room is a URL segment and the socket is public, treat the room id as a capability: gate access at the app layer if a call must be private.
+
+---
+
+## 7. The Chat WebSocket and History (secured)
+
+### `WS {p}/ws/chat/{channel}` -- secured
+
+The chat socket is registered with `.secure`, so a **valid JWT is required on the upgrade** -- an unauthenticated upgrade is rejected before the handler ever runs. The handler is `chat_handler(connection, event, data)`.
+
+- The channel is addressed by **integer id**: the handler requires `connection.params[:channel]` to match `\A\d+\z`. A non-integer channel makes the handler **return silently** -- the socket opens and does nothing, no error frame.
+- `identity = Tina4::Realtime.identity(connection.auth)` -- the String id from the verified token.
+- The room key is `chat:<channel_id>`.
+
+Every inbound frame is a JSON object; every broadcast is a `.to_json` String.
+
+| event / message `"type"` | server behavior |
+|---|---|
+| `:open` | Authorize. **Fail:** send `{"type":"error","error":"not a member of this channel"}` then `close`. **OK:** `join_room`, send the caller the roster `{"type":"presence","event":"roster","users":[...]}`, then broadcast `{"type":"presence","event":"join","user_id":<id>}` (exclude self). |
+| `:close` | Broadcast `{"type":"presence","event":"leave","user_id":<id>}` (exclude self). |
+| `"typing"` | Broadcast `{"type":"typing","user_id":<id>}` (exclude self). |
+| `"read"` | Advance the member's read cursor (`last_read_at = now`), broadcast `{"type":"read","user_id":<id>,"at":<iso8601>}` (exclude self). |
+| `"message"` | Strip `body`; empty/whitespace is **silently dropped**. Otherwise persist a `Message` row and broadcast `{"type":"message","message":<saved>}` to **everyone including the sender** -- so the sender's optimistic message reconciles with its server `id` and `created_at`. |
+
+`"type"` defaults to `"message"` when absent. Unknown types are ignored, and non-Hash payloads are ignored.
+
+**Authorization is re-checked on every inbound `:message` frame**, not just on join -- membership can be revoked mid-session, and the server never trusts an identity carried in the payload. The roster is the sorted, de-duplicated set of authenticated identities currently in the room, collected from each live connection's `auth`.
+
+A saved message (broadcast, and returned by history) has this shape:
+
+```jsonc
+{ "id": <int>, "channel_id": <int>, "user_id": "<str>", "body": "<str>",
+  "thread_id": <int|null>, "created_at": "<iso8601 Z>" }
+```
+
+`thread_id` is `null` for a top-level message, or the parent message id for a threaded reply.
+
+### `GET {p}/api/channels/{id}/messages` -- secured
+
+The catch-up-on-reconnect endpoint. A client opens the socket for live traffic and calls this to backfill what it missed.
+
+- Identity comes from `request.user` (the router-attached, verified JWT payload).
+- `channel_id <= 0` -- **400**; not authorized -- **403**; otherwise the message list.
+- Query params: `before` (return messages with `id < before`) and `limit` (default **50**, floored at 1, capped at **200**).
+- Returns messages **newest-first** -- the standard infinite-scroll-backwards shape. Each item uses the saved-message JSON above.
+
+```bash
+# Page backwards from message id 900, 50 at a time.
+curl -H "Authorization: Bearer $JWT" \
+  "http://localhost:7145/api/channels/42/messages?before=900&limit=50"
+```
+
+---
+
+## 8. Files: Upload / Download and Storage Backends
+
+Enabled with `features: %w[files]`. Files are stored through a `StorageBackend` (the `storage:` arg, or the env-selected store, default `LocalStorage`), resolved once at mount via `Tina4::Realtime::Storage.select(storage)`.
+
+### `POST {p}/api/files` -- upload
+
+- **Multipart**: file field **`file`** plus a form field **`channel_id`** (required, integer).
+- Invalid/missing `channel_id` -- **400**; not a channel member -- **403**; no file -- **400**.
+- The blob is stored under an opaque, collision-free `storage_key` (`SecureRandom.hex(16)` plus a sanitized, length-capped extension -- **never a user-controlled path**). An `Attachment` row records the metadata only, never the blob. Responds **201**:
+
+```jsonc
+{ "id": <int>, "key": "<storage_key>", "filename": "<str>", "mime": "<str>",
+  "size": <int>, "url": "<direct url OR {files}/{key}>" }
+```
+
+`url` is `store.url(key)` when the backend exposes a direct URL (e.g. an S3 presigned URL), otherwise the app download route `{files}/{key}`.
+
+This route is registered with `Tina4::Router.post(...)` **without** `.no_auth`, so the default **write-route bearer gate applies** -- a tokenless upload 401s.
+
+```bash
+curl -X POST http://localhost:7145/api/files \
+  -H "Authorization: Bearer $JWT" \
+  -F "channel_id=42" \
+  -F "file=@./diagram.png"
+```
+
+### `GET {p}/api/files/{key}` -- download (secured)
+
+- Looks up the `Attachment` by `storage_key`; missing -- **404**. Authorizes against the attachment's `channel_id`; a non-member -- **403**.
+- If the backend has a direct URL it **302-redirects** to it. Otherwise it **streams the bytes** (**200**) with `Content-Disposition: inline; filename="…"` and `Content-Type` set from `attachment.mime` (default `application/octet-stream`). A missing blob on disk -- **404**.
+
+The download route needs `.secure` because a `GET` is public by default; the upload does not, because writes already require a token.
+
+### Storage backends
+
+`Tina4::Realtime::Storage.select(storage = nil)` resolves from the `storage:` arg or `TINA4_STORAGE_BACKEND` (`local` default | `s3`). An `s3` backend that cannot be built -- the `aws-sdk-s3` gem is missing, or the config is incomplete -- **falls back to `LocalStorage` with a warning**. A real persistent store, never a silent no-op. (Ruby rescues both `StandardError` and `LoadError` here, because a missing gem raises `LoadError`, which is not a `StandardError`.)
+
+| var | default | effect |
+|---|---|---|
+| `TINA4_STORAGE_BACKEND` | `local` | `local` \| `s3`. |
+| `TINA4_STORAGE_DIR` | `data/rt_storage` | Local filesystem directory. |
+| `TINA4_STORAGE_URL` | -- | S3 endpoint URL (S3-compatible / MinIO); `force_path_style` is on. |
+| `TINA4_STORAGE_KEY` / `TINA4_STORAGE_SECRET` | -- | S3 credentials. |
+| `TINA4_STORAGE_BUCKET` | -- | S3 bucket (**required** for S3; raises `ArgumentError` if absent). |
+| `TINA4_STORAGE_REGION` | `us-east-1` | S3 region. |
+
+`LocalStorage` resolves every key inside its root and **rejects path traversal** (raises `ArgumentError` on an unsafe key); its `url` returns `nil`, so blobs are served by the permissioned download route. `S3Storage` returns a presigned GET URL from `url`, so clients fetch large blobs straight from object storage and skip your app server.
+
+You can also pass a custom backend instance directly:
+
+```ruby
+Tina4::Realtime.mount(features: %w[chat files], storage: MyStorageBackend.new)
+```
+
+---
+
+## 9. Auth and Identity
+
+Identity is always taken from the verified token -- never from the message body.
+
+- **`Tina4::Realtime.identity(auth)`** extracts a stable **String** user id from a verified JWT payload, trying claims **`user_id` -> `sub` -> `id`** in order (String or Symbol keys). It returns `nil` if `auth` is not a Hash or none of those claims are present. Identities round-trip as Strings, so an integer id, a UUID, or an email all work.
+- **WebSocket identity** comes from `connection.auth` (the verified payload attached on the secured upgrade). **HTTP identity** comes from `request.user` (router-attached). Ruby matches the PHP/Node ports here -- it does not re-parse the `Authorization` header the way Python's HTTP handlers do.
+- **`Tina4::Realtime.authorized?(identity, channel_id)`** is the shared guard for chat channels and file access. A `nil` identity is **always denied**. If a custom `authorize:` Proc was passed to `mount`, it wins (`!!proc.call(identity, channel_id)`); otherwise the secure default requires channel membership:
+
+  ```ruby
+  ChannelMember.count("channel_id = ? AND user_id = ?", [channel_id, identity]).positive?
+  ```
+
+  Any exception logs and returns `false` (deny).
+- A custom `authorize:` must be **cheap** -- it runs on every inbound chat frame, not just on join.
+
+### Data model
+
+The chat/files features own a small set of `Tina4::ORM` models, all with the **`tina4_rt_`** table prefix so they never collide with your app's own tables. Ruby is snake_case end to end -- columns, attributes, and JSON keys match with no mapping layer. Tables are created on demand at mount (`ensure_chat_tables` iterates them in dependency order).
+
+| model | table | key fields |
+|---|---|---|
+| `Workspace` | `tina4_rt_workspaces` | `id`, `name`, `created_at` |
+| `Channel` | `tina4_rt_channels` | `id`, `workspace_id`, `name`, `kind` (`public`\|`private`\|`dm`, default `public`), `created_at` |
+| `ChannelMember` | `tina4_rt_channel_members` | `id`, `channel_id`, `user_id` (String, <=128), `role` (default `member`), `last_read_at` (read cursor) |
+| `Message` | `tina4_rt_messages` | `id`, `channel_id`, `user_id` (String), `body` (Text), `thread_id` (nullable parent id), `created_at`, `edited_at` (nullable) |
+| `Attachment` | `tina4_rt_attachments` | `id`, `channel_id`, `message_id` (nullable), `storage_key`, `filename`, `mime`, `size`, `thumb_key` (nullable) |
+
+`workspace_id` and `channel_id` are plain integer FK columns queried directly (no ORM relationship wiring -- the control plane does not need it). `user_id` is a String everywhere, so any JWT identity shape fits.
+
+Add a member so the default guard lets them in:
+
+```ruby
+Tina4::Realtime::ChannelMember.new(
+  channel_id: 42, user_id: current_user_id.to_s, role: "member"
+).save
+```
+
+---
+
+## 10. A Complete Minimal Example
+
+Backend -- mount calls + chat + files, membership-gated by the default `ChannelMember` check:
+
+```ruby
+# app.rb -- after Tina4.initialize! and Tina4.bind_database(...)
+require "tina4"
+
+paths = Tina4::Realtime.mount(features: %w[calls chat files])
+Tina4::Log.info("realtime mounted: #{paths.inspect}")
+```
+
+Prefer a public channel open to any authenticated user? Pass a custom guard:
+
+```ruby
+Tina4::Realtime.mount(
+  features: %w[calls chat],
+  authorize: ->(identity, _channel_id) { !identity.nil? }   # keep it cheap -- runs per frame
+)
+```
+
+Frontend -- bootstrap from the config, then drive the sockets. This is exactly what the tina4-js `rtc` module does for you:
+
+```js
+// 1. Discover every path + the ICE servers from one public fetch.
+const cfg = await fetch("/api/rtc/config").then(r => r.json());
+
+// 2. Calls: mesh signalling over the public relay.
+const pc  = new RTCPeerConnection({ iceServers: cfg.iceServers });
+const sig = new WebSocket(`wss://${location.host}${cfg.signalling.replace("{room}", "room-42")}`);
+sig.onmessage = (e) => handleSignal(JSON.parse(e.data));   // offer / answer / ICE from peers
+
+// 3. Chat: JWT required on the upgrade (subprotocol carries the bearer token).
+const chatUrl = cfg.chat.replace("{channel}", "42");
+const chat = new WebSocket(`wss://${location.host}${chatUrl}`, ["bearer", jwt]);
+chat.onmessage = (e) => render(JSON.parse(e.data));        // presence / typing / read / message
+chat.onopen = () => chat.send(JSON.stringify({ type: "message", body: "Hello, channel." }));
+
+// 4. History: backfill on reconnect.
+const older = await fetch(cfg.messages.replace("{id}", "42") + "?limit=50",
+  { headers: { Authorization: `Bearer ${jwt}` } }).then(r => r.json());
+```
+
+Start it the usual way -- the WebSockets run alongside the HTTP server:
+
+```bash
+tina4 serve
+```
+
+---
+
+## 11. Footguns / Hard Rules
+
+- **Ruby is mesh-only; `TINA4_RTC_BACKEND` is ignored.** `mount` has **no `media:` param**, and the path map and config body hardcode `"backend" => "mesh"`. Setting `TINA4_RTC_BACKEND` does nothing in Ruby (it exists for cross-language config parity). An SFU/LiveKit backend is a future drop-in, not a Phase-1 option here.
+- **Chat needs a bound database -- but a missing one does NOT crash boot.** With `features:` that include `chat`/`files`, `ensure_chat_tables` runs at mount; if no DB is bound it **logs an error and continues**. `mount` still returns the full path map and registers every route -- the failure only surfaces at query time. Bind a DB (`Tina4.bind_database(db)` / `TINA4_DATABASE_URL`) **before** calling `mount(features: [...])`, or chat/history/files will error per request while the app looks healthy.
+- **The signalling WS (`/ws/rtc/{room}`) is PUBLIC.** It is not `.secure`, so anyone can join any room and receive relayed signalling frames. Only the **chat** WS is JWT-secured. Gate call access at the app layer if you need it.
+- **The config endpoint (`/api/rtc/config`) is PUBLIC** and returns your ICE/TURN config, including freshly-minted ephemeral TURN credentials.
+- **The WS handler signature is `(connection, event, data)` and `event` is a Symbol** (`:open` / `:message` / `:close`); `data` is the payload String on `:message`, `nil` otherwise. This is the Ruby framework convention -- **not** `(connection, data, event)`. (The PHP port fires `($connection, $data, $event)` -- argument order differs across languages.)
+- **Channels are addressed by integer id.** A non-integer `{channel}` makes the chat handler return silently (no error frame) -- the client sees a socket that opens and does nothing.
+- **Chat authorization is re-checked on every frame**, and identity is always taken from the verified token (`connection.auth` / `request.user`), never from the message payload. Keep a custom `authorize:` cheap.
+- **A message with an empty/whitespace `body` is silently dropped** (no persist, no broadcast). `read` / `typing` / unknown types never persist anything.
+- **Upload is protected by the default write gate, not `.secure`; download IS `.secure`.** Do not add `.no_auth` to the upload route thinking it needs auth added -- writes already require a token. The download route needs `.secure` only because a `GET` is public by default.


### PR DESCRIPTION
The 3.13.58 real-time feature (backend `realtime()`/`Realtime` + frontend `rtc`) had no website documentation. This adds a **Real-time (WebRTC)** chapter for every language, each verified against the framework source (not just the skill reference).

### New pages
| Page | Covers |
|---|---|
| `js/17-realtime-rtc.md` | frontend `rtc` module — config / call / chat / upload / fetchBlob |
| `python/39-realtime-webrtc.md` | `realtime()` mount, config bootstrap, ICE/TURN, signalling/chat WS, files |
| `php/39-realtime-webrtc.md` | `Realtime::mount()` — `($connection, $data, $event)` handler order |
| `ruby/38-realtime-webrtc.md` | `Tina4::Realtime.mount` — mesh-only (shipped 3.13.57) |
| `nodejs/38-realtime-webrtc.md` | `await realtime()` — async handler, hardcoded mesh |

### Wiring + fixes
- **config.mts** — extend the `Appendix` range to include ch39 (python/php) so the pages appear in the sidebar; add the `realtime-webrtc` title override.
- **llms.txt** — add real-time collaboration (WebRTC) to the built-ins list; update the skills reference to the now per-language split (`tina4-developer-<language>`, `tina4-js`, `tina4-maintainer`).
- **php/23-websocket.md — bug fix.** The WebSocket handler examples used `($connection, $event, $data)`, but the framework fires `($connection, $data, $event)` (Server.php L808/919/1192). The old order made every `if ($event === "message")` compare the *payload*, so the echo example never matched. Corrected throughout.

Verified: `vitepress build docs` succeeds; all 5 pages render and appear in each language's sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)