### PR TITLE
audit-links: match VitePress underscore-prefix for digit-leading heading slugs

### DIFF
--- a/scripts/audit-links.py
+++ b/scripts/audit-links.py
@@ -42,10 +42,19 @@ ALLOWLIST: set[tuple[str, str]] = set()
 
 
 def slugify(text: str) -> str:
-    """GitHub / VitePress-style heading slug."""
+    """VitePress-style heading slug.
+
+    Mirrors VitePress/markdown-it-anchor, which prefixes an underscore when the
+    slug would otherwise start with a digit (a leading digit is not a valid CSS
+    identifier) — e.g. `## 6. Calls` renders `id="_6-calls"`. The audit must match
+    that or every numbered-heading anchor is a false "missing-anchor".
+    """
     s = text.strip().lower()
     s = re.sub(r'[^\w\s\-]', '', s)
-    return re.sub(r'\s+', '-', s)
+    s = re.sub(r'\s+', '-', s)
+    if s and s[0].isdigit():
+        s = '_' + s
+    return s
 
 
 _anchor_cache: dict = {}


### PR DESCRIPTION
`audit-links.py`'s `slugify` didn't replicate VitePress/markdown-it-anchor's rule of prefixing an underscore when a heading slug starts with a digit — `## 6. Calls` renders `id="_6-calls"` in the built site, but the audit computed `6-calls`. So every link to a numbered heading (`#_6-...`) was a **false** "missing-anchor", even though it resolves in the deployed site.

Adds the underscore-prefix rule. **missing-anchor 208 → 201** — removes the false positives (including the in-page links on the new `*-realtime-webrtc` pages, verified against the built HTML); nothing newly flagged. The remaining 201 are pre-existing stale anchors in `v2/`/`index.md` (non-numeric), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)