### PR TITLE
install-skills: bump ref to 3.13.59

### DIFF
--- a/docs/public/install-skills.ps1
+++ b/docs/public/install-skills.ps1
@@ -2,14 +2,14 @@
 # Usage: irm https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.ps1 | iex
 #
 # Installs the tina4 AI skills into ~/.claude/skills so Claude Desktop / Claude Code
-# use Tina4 conventions out of the box. As of 3.13.58 the developer skill is split
+# use Tina4 conventions out of the box. As of 3.13.59 the developer skill is split
 # per language (each owned by its framework repo); tina4-js + tina4-maintainer are shared.
 # Stopgap until `tina4 skills install` ships embedded in the CLI binary.
 $ErrorActionPreference = "Stop"
 
 # Pin skills to a released tag, not a moving branch, so an install is reproducible.
 # Bump this when the skills change in a new release. Override with TINA4_SKILLS_REF.
-$ref  = if ($env:TINA4_SKILLS_REF) { $env:TINA4_SKILLS_REF } else { "3.13.58" }
+$ref  = if ($env:TINA4_SKILLS_REF) { $env:TINA4_SKILLS_REF } else { "3.13.59" }
 $dest = Join-Path $HOME ".claude\skills"
 
 $devRefs = @("auth-and-services.md", "data-and-orm.md", "deployment.md", "routes-and-api.md", "templates-and-frontend.md", "realtime.md")

--- a/docs/public/install-skills.sh
+++ b/docs/public/install-skills.sh
@@ -3,14 +3,14 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.sh | sh
 #
 # Installs the tina4 AI skills into ~/.claude/skills so Claude Desktop / Claude Code
-# use Tina4 conventions out of the box. As of 3.13.58 the developer skill is split
+# use Tina4 conventions out of the box. As of 3.13.59 the developer skill is split
 # per language (each owned by its framework repo); tina4-js + tina4-maintainer are shared.
 # Stopgap until `tina4 skills install` ships embedded in the CLI binary.
 set -euo pipefail
 
 # Pin skills to a released tag, not a moving branch, so an install is reproducible.
 # Bump this when the skills change in a new release. Override with TINA4_SKILLS_REF.
-ref="${TINA4_SKILLS_REF:-3.13.58}"
+ref="${TINA4_SKILLS_REF:-3.13.59}"
 dest="$HOME/.claude/skills"
 
 # install_skill <repo> <skill> <reference.md ...>


### PR DESCRIPTION
Mirror: point tina4.com/install-skills at 3.13.59. 🤖 Generated with [Claude Code](https://claude.com/claude-code)