### PR TITLE
docs: 3.13.67 release notes (MCP database_tables fix #164)

### DIFF
--- a/docs/nodejs/36-releases.md
+++ b/docs/nodejs/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser, locked down
+
+**The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what

--- a/docs/php/36-releases.md
+++ b/docs/php/36-releases.md
@@ -1,5 +1,11 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser lists your tables again
+
+**The `database_tables` dev-tool works again.** It called `getDatabase()`, a method the base `Database` does not carry, so every call fataled with "Call to undefined method" and returned an error instead of your table list. The tool now calls `getTables()`, the adapter contract that actually lists tables. Drive the dev MCP server from an AI client and "list the tables" answers correctly.
+
+The bug hid in plain sight because the test only checked that the tool was registered, never that it ran. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so a silent fatal cannot ship again. All four frameworks gained the same behavioural test; Python, Ruby, and Node already called the right method. Reported by skorteva (#164).
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what

--- a/docs/python/36-releases.md
+++ b/docs/python/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser, locked down
+
+**The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what

--- a/docs/ruby/36-releases.md
+++ b/docs/ruby/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser, locked down
+
+**The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what


### PR DESCRIPTION
3.13.67 release notes across all four framework release-note files. PHP describes the getDatabase()->getTables() fix that un-fataled the database_tables MCP dev-tool; Python/Ruby/Node note the parity behavioural lock-in test. audit-truth --strict + pnpm docs:build both green. ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)