### PR TITLE
docs: delegate skill installers to Tina4 client

### DIFF
--- a/docs/public/install-skills.ps1
+++ b/docs/public/install-skills.ps1
@@ -1,51 +1,9 @@
-# Tina4 AI skills installer for Windows
-# Usage: irm https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.ps1 | iex
+# Tina4 documentation installer entry point.
+# The installer implementation lives in tina4stack/tina4 so the published
+# documentation and the Tina4 client always use the same target selection.
 #
-# Installs the tina4 AI skills into ~/.claude/skills so Claude Desktop / Claude Code
-# use Tina4 conventions out of the box. As of 3.13.66 the developer skill is split
-# per language (each owned by its framework repo); tina4-js + tina4-maintainer are shared.
-# Stopgap until `tina4 skills install` ships embedded in the CLI binary.
+# Examples:
+#   $env:TINA4_SKILLS_TARGET = "claude"; irm https://tina4.com/install-skills.ps1 | iex
+#   $env:TINA4_SKILLS_TARGET = "codex"; irm https://tina4.com/install-skills.ps1 | iex
 $ErrorActionPreference = "Stop"
-
-# Pin skills to a released tag, not a moving branch, so an install is reproducible.
-# Bump this when the skills change in a new release. Override with TINA4_SKILLS_REF.
-$ref  = if ($env:TINA4_SKILLS_REF) { $env:TINA4_SKILLS_REF } else { "3.13.77" }
-$dest = Join-Path $HOME ".claude\skills"
-
-$devRefs = @("auth-and-services.md", "data-and-orm.md", "deployment.md", "routes-and-api.md", "templates-and-frontend.md", "realtime.md")
-
-# repo, skill, reference files. Per-language developer skills come from their own
-# framework repo; tina4-js + tina4-maintainer are shared (served from tina4-python).
-$installs = @(
-  @{ repo = "tina4-python"; skill = "tina4-developer-python"; refs = $devRefs }
-  @{ repo = "tina4-php";    skill = "tina4-developer-php";    refs = $devRefs }
-  @{ repo = "tina4-ruby";   skill = "tina4-developer-ruby";   refs = $devRefs }
-  @{ repo = "tina4-nodejs"; skill = "tina4-developer-nodejs"; refs = $devRefs }
-  @{ repo = "tina4-python"; skill = "tina4-js";               refs = @("html-and-components.md", "signals-and-reactivity.md", "persistence.md", "rtc.md") }
-  @{ repo = "tina4-python"; skill = "tina4-maintainer";       refs = @("cli-and-deployment.md", "frond-and-frontend.md", "routing-and-orm.md", "subsystems.md") }
-)
-
-Write-Host ""
-Write-Host "  Tina4 Skills Installer" -ForegroundColor Cyan
-Write-Host "  Installing to: $dest  (ref: $ref)" -ForegroundColor Cyan
-Write-Host ""
-
-foreach ($i in $installs) {
-  $base   = "https://raw.githubusercontent.com/tina4stack/$($i.repo)/$ref/.claude/skills"
-  $refdir = Join-Path $dest "$($i.skill)\references"
-  New-Item -ItemType Directory -Path $refdir -Force | Out-Null
-  Invoke-WebRequest -Uri "$base/$($i.skill)/SKILL.md" -OutFile (Join-Path $dest "$($i.skill)\SKILL.md")
-  foreach ($r in $i.refs) {
-    Invoke-WebRequest -Uri "$base/$($i.skill)/references/$r" -OutFile (Join-Path $refdir $r)
-  }
-  Write-Host "  + $($i.skill)  ($($i.repo))" -ForegroundColor Green
-}
-
-# Record the installed ref so `tina4 doctor` can report skills currency. This is
-# a GLOBAL marker under ~/.claude/skills only - it NEVER touches a project's
-# CLAUDE.md or any project file.
-Set-Content -Path (Join-Path $dest ".tina4-skills-ref") -Value $ref -NoNewline
-
-Write-Host ""
-Write-Host "  Done - six skills installed (ref $ref). Restart Claude (Desktop/Code) to pick them up." -ForegroundColor Green
-Write-Host ""
+Invoke-RestMethod https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.ps1 | Invoke-Expression

--- a/docs/public/install-skills.sh
+++ b/docs/public/install-skills.sh
@@ -1,51 +1,10 @@
 #!/usr/bin/env bash
-# Tina4 AI skills installer for macOS / Linux
-# Usage: curl -fsSL https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.sh | sh
+# Tina4 documentation installer entry point.
+# The installer implementation lives in tina4stack/tina4 so the published
+# documentation and the Tina4 client always use the same target selection.
 #
-# Installs the tina4 AI skills into ~/.claude/skills so Claude Desktop / Claude Code
-# use Tina4 conventions out of the box. As of 3.13.66 the developer skill is split
-# per language (each owned by its framework repo); tina4-js + tina4-maintainer are shared.
-# Stopgap until `tina4 skills install` ships embedded in the CLI binary.
+# Examples:
+#   curl -fsSL https://tina4.com/install-skills.sh | TINA4_SKILLS_TARGET=claude sh
+#   curl -fsSL https://tina4.com/install-skills.sh | TINA4_SKILLS_TARGET=codex sh
 set -euo pipefail
-
-# Pin skills to a released tag, not a moving branch, so an install is reproducible.
-# Bump this when the skills change in a new release. Override with TINA4_SKILLS_REF.
-ref="${TINA4_SKILLS_REF:-3.13.77}"
-dest="$HOME/.claude/skills"
-
-# install_skill <repo> <skill> <reference.md ...>
-install_skill() {
-  repo="$1"; skill="$2"; shift 2
-  base="https://raw.githubusercontent.com/tina4stack/${repo}/${ref}/.claude/skills"
-  mkdir -p "$dest/$skill/references"
-  curl -fsSL "$base/$skill/SKILL.md" -o "$dest/$skill/SKILL.md"
-  for r in "$@"; do
-    curl -fsSL "$base/$skill/references/$r" -o "$dest/$skill/references/$r"
-  done
-  echo "  + $skill  ($repo)"
-}
-
-DEV_REFS="auth-and-services.md data-and-orm.md deployment.md routes-and-api.md templates-and-frontend.md realtime.md"
-
-echo ""
-echo "  Tina4 Skills Installer"
-echo "  Installing to: $dest  (ref: $ref)"
-echo ""
-
-# Per-language developer skills (each from its own framework repo)
-install_skill tina4-python  tina4-developer-python  $DEV_REFS
-install_skill tina4-php     tina4-developer-php     $DEV_REFS
-install_skill tina4-ruby    tina4-developer-ruby    $DEV_REFS
-install_skill tina4-nodejs  tina4-developer-nodejs  $DEV_REFS
-# Shared skills (canonical copy served from tina4-python)
-install_skill tina4-python  tina4-js          html-and-components.md signals-and-reactivity.md persistence.md rtc.md
-install_skill tina4-python  tina4-maintainer  cli-and-deployment.md frond-and-frontend.md routing-and-orm.md subsystems.md
-
-# Record the installed ref so `tina4 doctor` can report skills currency. This is
-# a GLOBAL marker under ~/.claude/skills only — it NEVER touches a project's
-# CLAUDE.md or any project file.
-printf '%s\n' "$ref" > "$dest/.tina4-skills-ref"
-
-echo ""
-echo "  Done — six skills installed (ref $ref). Restart Claude (Desktop/Code) to pick them up."
-echo ""
+curl -fsSL https://raw.githubusercontent.com/tina4stack/tina4/main/install-skills.sh | sh


### PR DESCRIPTION
Use the canonical Tina4 client skill installers so public docs do not drift from Claude/Codex target support.