### PR TITLE
Correct the Python quick reference against a running server, and sync Chapter 1

### DIFF
--- a/docs/python/01-getting-started.md
+++ b/docs/python/01-getting-started.md
@@ -2,11 +2,11 @@
 
 ## 1. What Is Tina4 Python
 
-Tina4 Python is a web framework for Python 3.12+. The core package declares no required third-party dependencies. Optional packages enable selected database, cache, queue, MongoDB, and S3 providers. Tina4 Python contributes to the framework family's 135-entry feature catalog; the catalog is an inventory, not a claim that every entry has reached parity.
+Tina4 Python is a zero-dependency web framework for Python 3.12+. The core package declares no required third-party dependencies; optional packages enable selected database, cache, queue, MongoDB, and S3 providers. Routing, ORM, template engine, authentication, queues, and WebSocket are all built in. Tina4 Python contributes to the framework family's 135-entry feature catalog, listed in [Chapter 38: Complete Feature List](38-feature-list.md); the catalog is an inventory, not a claim that every entry has reached parity.
 
 It belongs to the Tina4 family: four backend implementations in Python, PHP, Ruby, and Node.js. They share contracts, project structure, template syntax, CLI commands, and `.env` variables. The parity audit records where an implementation still differs.
 
-Tina4 Python follows Python convention: `snake_case` for methods and functions (`fetch_one()`, `soft_delete()`, `has_many()`), `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants. Route handlers are `async def` functions decorated with `@get`, `@post`, and friends.
+Tina4 Python follows Python convention: `snake_case` for methods and functions (`fetch_one()`, `soft_delete()`, `has_many()`), `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants. Route handlers are decorated with `@get`, `@post`, and friends, and are written `async def` by convention -- the server is asyncio, so an `async` handler can `await` without blocking it.
 
 By the end of this chapter, you will have a running Tina4 Python project with an API endpoint and a rendered HTML page.
 
@@ -27,10 +27,13 @@ python3 --version
 You should see output like:
 
 ```
-Python 3.12.3
+Python 3.x.x
 ```
 
-If you see a version lower than 3.12, upgrade Python first.
+If you see a version lower than 3.12, or no Python at all, install it from
+[python.org/downloads](https://www.python.org/downloads/). On Windows, tick *Add python.exe to
+PATH* in the installer, or the `tina4` CLI will not find it -- and Windows names the command
+`python`, not `python3`.
 
 2. **uv** -- a fast Python package manager and project tool. Check with:
 
@@ -41,20 +44,17 @@ uv --version
 You should see:
 
 ```
-uv 0.6.9
+uv 0.x.x
 ```
 
-If uv is not installed, get it from [https://docs.astral.sh/uv/](https://docs.astral.sh/uv/):
+If uv is not installed, get it from
+[docs.astral.sh/uv/getting-started/installation](https://docs.astral.sh/uv/getting-started/installation/),
+which covers every platform including Homebrew, winget and pipx. Python and uv are other
+people's tools, so this book links their instructions rather than copying them -- installers
+change, and a copy here would go stale without anyone noticing.
 
-```bash
-# macOS / Linux
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-3. **The Tina4 CLI** -- a Rust-based binary that manages all four Tina4 frameworks:
+3. **The Tina4 CLI** -- a Rust-based binary that manages all four Tina4 frameworks. This one is
+ours, so the commands are here:
 
 **macOS (Homebrew):**
 
@@ -65,13 +65,13 @@ brew install tina4stack/tap/tina4
 **Linux / macOS (install script):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tina4stack/tina4/main/install.sh | bash
+curl -fsSL https://tina4.com/install.sh | sh
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/tina4stack/tina4/main/install.ps1 | iex
+irm https://tina4.com/install.ps1 | iex
 ```
 
 Verify the CLI is installed:
@@ -81,18 +81,41 @@ tina4 --version
 ```
 
 ```
-tina4 0.1.0
+tina4 3.x.x
 ```
 
-## Installing the Tina4 CLI
+The `tina4` CLI manages project scaffolding, development servers, migrations, and more across all Tina4 frameworks. Binaries are also on [GitHub Releases](https://github.com/tina4stack/tina4/releases).
+
+### Check What the CLI Found
+
+Before scaffolding anything, ask the CLI what it can see:
 
 ```bash
-cargo install tina4
+tina4 doctor
 ```
 
-Or download from [GitHub Releases](https://github.com/tina4stack/tina4/releases).
+```
+  Tina4 Doctor - Environment Check
 
-The `tina4` CLI manages project scaffolding, development servers, migrations, and more across all Tina4 frameworks.
+  Language     Status     Version              Pkg Mgr      Version
+  ──────────────────────────────────────────────────────────────────────
+  Python       ✓          3.x.x                ✓ uv         0.x.x
+  PHP          ✓          8.x.x                ✓ composer   2.x.x
+  Ruby         ✓          3.x.x                ✓ bundler    2.x.x
+  Node.js      ✓          22.x.x               ✓ npm        10.x.x
+
+  Tina4 CLIs
+  ──────────────────────────────────────────────────────────────────────
+  ✓ tina4python      Python       installed (global)
+  ✓ tina4php         PHP          installed (global)
+  ✓ tina4ruby        Ruby         installed (global)
+  ✗ tina4nodejs      Node.js      not found  ->  run: npm install -g tina4-nodejs
+  ✗ vite             tina4js      not found  ->  run: npm install vite
+```
+
+Only the Python row matters for this chapter. A `✗` on a language you are not using is fine.
+`doctor` also reports the installed Tina4 AI skills and which ports are free; both are trimmed
+here.
 
 ### Creating a New Project
 
@@ -102,73 +125,74 @@ One command. One package. No dependency tree.
 tina4 init python my-store
 ```
 
-`tina4 init` installs the Tina4 CLI globally (via cargo, homebrew, or direct download), then scaffolds a complete project with routes, templates, database, and configuration.
+`tina4 init` takes a language and a **path**, and the path is not optional. It scaffolds a complete project at that path -- routes, templates, database, configuration -- builds a virtual environment inside it, and installs the dependency. There is no separate `uv sync` step.
+
+`tina4 setup` is the guided alternative: it asks once where your projects should live, remembers the answer in `~/.tina4/setup.conf`, and scaffolds there. From then on `tina4 serve my-store` finds the project from any directory.
 
 You should see:
 
 ```
-Creating Tina4 project in ./my-store ...
-  Detected language: Python (pyproject.toml)
-  Created .env
-  Created .env.example
-  Created .gitignore
-  Created src/routes/
-  Created src/orm/
-  Created migrations/
-  Created src/seeds/
-  Created src/templates/
-  Created src/templates/errors/
-  Created src/public/
-  Created src/public/js/
-  Created src/public/css/
-  Created src/public/scss/
-  Created src/public/images/
-  Created src/public/icons/
-  Created src/locales/
-  Created data/
-  Created logs/
-  Created secrets/
-  Created tests/
+▶ Initialising python project at /home/you/my-store
 
-Project created! Next steps:
-  cd my-store
-  uv sync
-  tina4 serve
+▶ Checking python runtime...
+  ✓ python3 found
+
+▶ Checking package manager...
+  ✓ uv found
+  ✓ Created directory /home/you/my-store
+
+▶ Scaffolding python project...
+  ✓ Created directory structure
+  ✓ Created .env
+  ✓ Created app.py
+  ✓ Created .gitignore
+  ✓ Created pyproject.toml
+  ✓ Created Python scaffold
+
+▶ Installing dependencies...
+  ▶ Running: uv sync (in /home/you/my-store)
+Using CPython 3.x.x interpreter at: /usr/bin/python3
+Creating virtual environment at: .venv
+Resolved 2 packages in 3.81s
+Installed 1 package in 15ms
+ + tina4-python==3.x.x
+  ✓ Dependencies installed
+
+✓ Project created at /home/you/my-store
+
+  Start the server now? [Y/n]:
 ```
 
-Install the Python dependencies:
+`Resolved 2 packages` is the whole dependency graph: your project and `tina4-python`. One
+package. No dependency tree. No version conflicts.
 
-```bash
-cd my-store
-uv sync
-```
+Everything the project needs lives under that one directory, `.venv/` included, so there is
+nothing installed globally and nothing to clean up elsewhere. Delete the directory and the
+project is gone.
 
-```
-Resolved 1 package in 0.8s
-Installed 1 package in 0.3s
- + tina4-python==3.1.0
-```
-
-One package. No dependency tree. No version conflicts. Just `tina4-python`.
+Answer `n` for now -- we will start the server deliberately in the next section.
 
 ### Starting the Dev Server
 
 ```bash
+cd my-store
 tina4 serve
 ```
 
 ```
- _____ _             _  _
-|_   _(_)_ __   __ _| || |
-  | | | | '_ \ / _` | || |_
-  | | | | | | | (_| |__   _|
-  |_| |_|_| |_|\__,_|  |_|
+  ______ _             __ __
+ /_  __/(_)___  ____ _/ // /
+  / /  / / __ \/ __ `/ // /_
+ / /  / / / / / /_/ /__  __/
+/_/  /_/_/ /_/\__,_/  /_/
 
-  Tina4 Python v3.2.0
-  Server running at http://0.0.0.0:7146
-  Debug mode: ON
-  Database: sqlite:///data/app.db
-  Press Ctrl+C to stop
+  Tina4 Python v3.x.x - The Intelligent Native Application 4ramework
+
+  Server:    http://localhost:7146 (asyncio)
+  Swagger:   http://localhost:7146/swagger
+  Dashboard: http://localhost:7146/__dev
+  Debug:     ON (Log level: ALL)
+  Test Port: http://localhost:8146 (stable - no hot-reload)
 ```
 
 Open your browser to `http://localhost:7146`. The Tina4 welcome page greets you.
@@ -180,14 +204,11 @@ curl http://localhost:7146/health
 ```
 
 ```json
-{
-  "status": "ok",
-  "database": "connected",
-  "uptime_seconds": 12,
-  "version": "3.2.0",
-  "framework": "tina4-python"
-}
+{"status":"ok","version":"3.x.x","uptime":0.83,"framework":"tina4-python"}
 ```
+
+`/health` and `/__health` both answer. It is a liveness probe for the process, so it reports
+no database or cache state.
 
 Your Tina4 Python project is running.
 
@@ -195,14 +216,16 @@ Your Tina4 Python project is running.
 
 ## 3. Project Structure Walkthrough
 
-Here is what `tina4 init` created:
+Here is what you have after `tina4 init` and the first `tina4 serve`:
 
 ```
 my-store/
+├── app.py                  # Entry point -- imports the framework and calls run()
 ├── .env                    # Your configuration (gitignored)
-├── .env.example            # Template for other developers
+├── .env.local              # Dev auth secret, written on first serve (gitignored)
 ├── .gitignore              # Pre-configured
 ├── pyproject.toml          # Python project definition (uv / pip)
+├── uv.lock                 # Resolved dependency lock file
 ├── .venv/                  # Virtual environment (gitignored)
 ├── migrations/             # SQL migration files (project root)
 ├── src/
@@ -210,22 +233,23 @@ my-store/
 │   ├── orm/                # Your ORM model classes go here
 │   ├── seeds/              # Database seed files
 │   ├── templates/          # Frond templates
-│   │   └── errors/         # Custom 404.html, 500.html
-│   ├── public/             # Static files (CSS, JS, images)
+│   │   └── errors/         # Your custom error pages
+│   ├── public/             # Static files, served from /
 │   │   ├── js/
-│   │   │   └── frond.js    # Auto-provided JS helper library
 │   │   ├── css/
-│   │   │   └── tina4.css   # Built-in CSS utility framework
-│   │   ├── scss/
 │   │   ├── images/
 │   │   └── icons/
+│   ├── scss/               # SCSS sources, compiled into src/public/css/
 │   └── locales/            # Translation files
-│       └── en.json
 ├── data/                   # SQLite databases (gitignored)
 ├── logs/                   # Log files (gitignored)
 ├── secrets/                # JWT keys (gitignored)
 └── tests/                  # Your test files
 ```
+
+`init` writes `app.py`, `.env`, `.gitignore` and `pyproject.toml`; the convention directories
+are created and kept in place by the server. They start empty -- there is no sample route,
+template or locale file to delete.
 
 **Key directories:**
 
@@ -356,6 +380,17 @@ curl -X POST http://localhost:7146/api/greeting \
 ```json
 {"message":"Hola, Carlos!","language":"es"}
 ```
+
+> **On Windows**, run these from PowerShell as `curl.exe`, on a single line. Plain `curl` is an
+> alias for `Invoke-WebRequest`, which takes different arguments, and `\` is not a line
+> continuation character:
+>
+> ```powershell
+> curl.exe -X POST http://localhost:7146/api/greeting -H "Content-Type: application/json" -d '{"name": "Carlos", "language": "es"}'
+> ```
+>
+> The same applies to every `curl` example below. Everything else in this chapter -- the
+> `tina4` CLI, `uv`, `.env` variables -- is identical on Linux, macOS and Windows.
 
 The HTTP status code is `201 Created` (the second argument to `response.json()`).
 
@@ -506,7 +541,9 @@ Eight steps. All automatic.
 
 ### About tina4css
 
-The `tina4.css` file is Tina4's built-in CSS utility framework. Layout utilities. Typography. Common UI patterns. No Bootstrap. No Tailwind. No download. It ships with every scaffolded project.
+The `tina4.css` file is Tina4's built-in CSS utility framework. Layout utilities. Typography. Common UI patterns. No Bootstrap. No Tailwind. No download.
+
+It is served by the framework itself, so there is no copy in your project to find or maintain -- link it at `/css/tina4.css`. The same is true of `frond.js` at `/js/frond.js`.
 
 ---
 
@@ -527,8 +564,9 @@ The important defaults for development:
 | `TINA4_PORT` | `7146` | Default server port (override with `tina4 serve --port`) |
 | `TINA4_DATABASE_URL` | `sqlite:///data/app.db` | SQLite database in the `data/` directory |
 | `TINA4_LOG_LEVEL` | `ALL` | All log messages are output |
-| `CORS_ORIGINS` | `*` | All origins allowed (fine for development) |
-| `TINA4_RATE_LIMIT` | `60` | 60 requests per minute per IP |
+| `TINA4_CORS_ORIGINS` | unset | Deny by default -- no cross-origin request is allowed until you list the origins (`*` has to be asked for) |
+| `TINA4_RATE_LIMIT` | `100` | Requests allowed per window, per IP |
+| `TINA4_RATE_WINDOW` | `60` | Window length in seconds, so the default is 100 requests per minute |
 
 **Log levels** control how much output Tina4 produces:
 
@@ -556,14 +594,19 @@ TINA4_PORT=8080
 
 Restart the server. It now runs on port 8080.
 
-**How port resolution works:** The Rust CLI (`tina4 serve`) determines the port using this priority order:
+**Setting the port.** Three ways, and the framework default if you use none of them:
 
-1. **CLI flag** (highest priority): `tina4 serve --port 8080`
-2. **`.env` file**: `TINA4_PORT=8080`
-3. **Environment variable**: `PORT=8080`
-4. **Framework default** (PHP: 7145, Python: 7146, Ruby: 7147, Node.js: 7148)
+```bash
+tina4 serve --port 8080        # for one run
+```
 
-The CLI reads your `.env` file and checks for `TINA4_PORT` (and falls back to `PORT`). The resolved port is passed to the Python server. All three methods work -- use whichever fits your workflow.
+```bash
+TINA4_PORT=8080                # in .env, for every run
+```
+
+A bare `PORT` variable is also read, for hosts that set it, but it is deprecated and goes away
+in 3.14 -- use `TINA4_PORT`. The defaults per framework are PHP 7145, Python 7146, Ruby 7147
+and Node.js 7148.
 
 For the complete `.env` reference with all 68 variables, see [Environment Variables](./33-environment-variables.md).
 
@@ -650,6 +693,12 @@ Create the directories:
 
 ```bash
 mkdir -p src/routes src/templates src/public
+```
+
+On Windows, from PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force -Path src/routes, src/templates, src/public
 ```
 
 ### Step 4: Create `.env`
@@ -1077,27 +1126,25 @@ async def store_page(request, response):
 
 **Problem:** You created a route file but nothing happens when you visit the URL.
 
-**Cause:** The file is not in `src/routes/`. It must be inside `src/routes/` (or a subdirectory), and the file must end with `.py`.
+**Cause:** The file is not in `src/routes/`. It must be inside `src/routes/` (or a subdirectory), and the file must end with `.py`. Names beginning with `_` are treated as private and not loaded.
 
 **Fix:** Move the file to `src/routes/your-file.py` and restart the server.
 
-### 2. Missing import
+### 2. Route file did not import
 
-**Problem:** `NameError: name 'get' is not defined` or similar.
+**Problem:** The URL 404s.
 
-**Cause:** You forgot to import the route decorator.
+**Cause:** The file did not import, so none of its routes registered -- a missing decorator import is the usual reason. The framework logs the reason and keeps serving the rest of the app.
 
-**Fix:** Start your route file with the correct import: `from tina4_python.core.router import get, post` (include whichever decorators you need).
+**Fix:** Read the server output. The reason is there:
 
-### 3. Handler not async
+```
+[ERROR] Failed to load /home/you/my-store/src/routes/greeting.py: name 'get' is not defined
+```
 
-**Problem:** Your route handler runs but returns an error about a coroutine object.
+Start your route file with the correct import: `from tina4_python.core.router import get, post` (include whichever decorators you need). A route that 404s unexpectedly is usually a file that did not load.
 
-**Cause:** You defined the handler with `def` instead of `async def`. Tina4 Python expects all route handlers to be async.
-
-**Fix:** Change `def greeting(request, response):` to `async def greeting(request, response):`. Every route handler must be `async def`.
-
-### 4. Template not found
+### 3. Template not found
 
 **Problem:** `Template "my-page.html" not found` error.
 
@@ -1105,21 +1152,21 @@ async def store_page(request, response):
 
 **Fix:** Check that the file exists at `src/templates/my-page.html`. The name in `response.render()` is relative to `src/templates/`.
 
-### 5. Port already in use
+### 4. Port already in use
 
-**Problem:** `Error: Address already in use (port 7146)`
+**Problem:** Another process is on port 7146.
 
-**Cause:** Another process (or another Tina4 instance) is using port 7146.
+**Cause:** Another process -- often a Tina4 server you forgot to stop.
 
-**Fix:** Stop the other process, or change the port with the CLI flag:
+**Fix:** Stop the other process, or move Tina4 with the CLI flag:
 
 ```bash
 tina4 serve --port 8080
 ```
 
-The CLI will also auto-increment the port if it detects the default port is in use.
+Or set `TINA4_PORT` in `.env` if you want it to stick.
 
-### 6. Changes not reflected
+### 5. Changes not reflected
 
 **Problem:** You edited a file but the browser shows the old version.
 
@@ -1127,7 +1174,7 @@ The CLI will also auto-increment the port if it detects the default port is in u
 
 **Fix:** Hard-refresh the browser (`Ctrl+Shift+R` or `Cmd+Shift+R`). If that fails, restart the dev server with `Ctrl+C` and `tina4 serve`.
 
-### 7. .env not loaded
+### 6. .env not loaded
 
 **Problem:** Environment variables have no effect.
 

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -5,6 +5,7 @@
 * Routes go in `src/routes/`, templates in `src/templates/`, static files in `src/public/`
 * GET routes are public by default; POST/PUT/PATCH/DELETE require a token
 * Return a `dict` from `response()` and the framework sets `application/json`
+* A route file whose name starts with `_` is treated as private and not loaded
 * Run `tina4 serve` to start the dev server on port 7146
 :::
 
@@ -13,7 +14,8 @@
 ### Installation <a href="#installation" id="installation"></a>
 
 ```bash
-# Install the tina4 CLI once. Windows: irm https://tina4.com/install.ps1 | iex
+# Install the tina4 CLI once. macOS: brew install tina4stack/tap/tina4
+# Windows (PowerShell): irm https://tina4.com/install.ps1 | iex
 curl -fsSL https://tina4.com/install.sh | sh
 
 tina4 init python my-app
@@ -21,17 +23,27 @@ cd my-app
 tina4 serve
 ```
 
-The CLI scaffolds your project, installs the dependencies, and starts the server. No dependency tree. No version conflicts. Your browser opens to `http://localhost:7146` and the welcome page greets you.
+`init` takes a language and a path, and the path is required. It scaffolds the project and installs the dependency -- one package, no tree, no version conflicts -- then asks `Start the server now? [Y/n]`. `serve` starts the server and opens your browser on `http://localhost:7146`, where the welcome page greets you.
+
+`tina4 setup` is the guided alternative: it asks once where your projects live, scaffolds there, and `tina4 serve my-app` then finds the project from any directory.
+
+The `tina4` CLI, `uv`, `.env` variables and the framework itself behave identically on Linux, macOS and Windows.
 
 [More details](01-getting-started.md) on project setup and customization.
 
 ### Static Websites <a href="#static-websites" id="static-websites"></a>
 
-Put `.twig` files in `./src/templates` and assets in `./src/public`. The framework serves them without additional configuration.
+Anything in `./src/public` is served from `/` with no configuration: `src/public/images/logo.png` is at `/images/logo.png`.
 
-```twig
-<!-- src/templates/index.twig -->
-<h1>Hello Static World</h1>
+Templates in `./src/templates` render through a route. Return one from a handler, or use `@template`, which sits below the route decorator:
+
+```python
+from tina4_python.core.router import get, template
+
+@get("/about")
+@template("about.twig")
+async def about(request, response):
+    return {"title": "About us"}
 ```
 
 [More details](04-templates.md) on static website routing.
@@ -64,6 +76,8 @@ Follow the links for [basic routing](02-routing.md) and [dynamic routing](02-rou
 
 Middleware runs before and after your route handler. Define a class with static methods, then attach it with the `@middleware` decorator.
 
+Hooks are discovered by prefix: `before_*` runs before the handler, `after_*` runs after. `response.content` holds **bytes**, so append bytes.
+
 ```python
 from tina4_python import get, middleware
 
@@ -71,24 +85,21 @@ class RunSomething:
 
     @staticmethod
     def before_something(request, response):
-        response.content += "Before"
+        response.content += b"Before"
         return request, response
 
     @staticmethod
     def after_something(request, response):
-        response.content += "After"
-        return request, response
-
-    @staticmethod
-    def before_and_after_something(request, response):
-        response.content += "[Before / After Something]"
+        response.content += b"After"
         return request, response
 
 @middleware(RunSomething)
 @get("/middleware")
 async def get_middleware(request, response):
-    return response("Route") # Before[Before / After Something]Route[Before / After Something]After
+    return response("Route")
 ```
+
+Use `before_*` to inspect or reject a request, and `after_*` to modify the outgoing body. Middleware is additive and does not change a route's auth requirement: POST, PUT, PATCH and DELETE stay token-gated. Use `@noauth()` to open a write route.
 
 Follow the links for more on [Middleware Declaration](10-middleware-security.md) and [Linking to Routes](10-middleware-security.md#routes).
 
@@ -116,13 +127,8 @@ The default session handler stores data on the file system. Override `TINA4_SESS
 The value is the backend name, not a class name, and it is normalised: leading or
 trailing spaces and capitals are fine, so `` Redis `` resolves.
 
-An unrecognised value RAISES at startup, naming the bad value and the valid ones.
-It used to fall back to the file backend silently, which meant a typo produced a
-running app writing sessions to local disk while you believed they were in Redis:
-nothing logged, nothing failed, and the symptom only surfaced later as users being
-logged out whenever a request landed on another instance. Leaving
-`TINA4_SESSION_BACKEND` unset, or setting it to an empty value, still gives you the
-file default.
+An unrecognised value RAISES at startup, naming the bad value and the valid ones. Leave
+`TINA4_SESSION_BACKEND` unset, or set it to an empty value, for the file default.
 
 | Value                    | Backend     | Required package |
 | ------------------------ | ----------- | ---------------- |
@@ -130,7 +136,10 @@ file default.
 | `redis`                  | Redis       | `redis`          |
 | `valkey`                 | Valkey      | `valkey`         |
 | `mongodb`                | MongoDB     | `pymongo`        |
+| `memcached`              | Memcached   | --               |
 | `database`               | Your ORM DB | --               |
+
+Aliases are accepted: `filesystem`, `mongo`, `memcache`, `db`. The memcached handler speaks the text protocol over a socket, so it needs no client library.
 
 ```bash
 TINA4_SESSION_BACKEND=mongodb
@@ -183,7 +192,7 @@ The `.env` file holds your project configuration. The framework reads it at star
 
 ```
 TINA4_DEBUG=true
-TINA4_PORT=7145
+TINA4_PORT=7146
 TINA4_DATABASE_URL=sqlite:///data/app.db
 TINA4_LOG_LEVEL=ALL
 TINA4_API_KEY=ABC1234
@@ -202,15 +211,19 @@ from tina4_python.dotenv import load_env, get_env, has_env, require_env, is_trut
 
 load_env()                          # Load .env file (auto on server start)
 get_env("TINA4_DATABASE_URL")             # Get value or None
-get_env("PORT", "7145")             # Get value with default
+get_env("PORT", "7146")             # Get value with default
 has_env("TINA4_DEBUG")              # True if set
 require_env("TINA4_DATABASE_URL")         # Raises if missing
 is_truthy(get_env("TINA4_DEBUG"))   # True for "true", "1", "yes"
 ```
 
+All 68 variables: [Chapter 33: Environment Variables](33-environment-variables.md).
+
 ### Authentication <a href="#authentication" id="authentication"></a>
 
 POST, PUT, PATCH, and DELETE routes require a Bearer token by default. Pass `Authorization: Bearer TINA4_API_KEY` in the request header. Use `@noauth()` to open a route to everyone. Use `@secured()` to lock a GET route behind authentication.
+
+Without `@noauth()`, an unauthenticated POST returns `{"error":"Unauthorized","message":"Valid authorization token required","status":401}`.
 
 ```python
 from tina4_python import get, post, noauth, secured
@@ -236,9 +249,11 @@ async def verify(request, response):
 
 ### HTML Forms and Tokens <a href="#html-forms-and-tokens" id="html-forms-and-tokens"></a>
 
+`form_token` works as a function or a filter. Both emit the hidden `formToken` input that satisfies the POST auth check for browser form submissions.
+
 ```twig
 <form method="POST" action="/register">
-    {{ ("Register" ~ RANDOM()) | form_token }}
+    {{ form_token() }}
     <input name="email">
     <button>Save</button>
 </form>
@@ -254,7 +269,7 @@ Tina4 ships with frond.js, a small zero-dependency JavaScript library for AJAX c
 
 ### OpenAPI and Swagger UI <a href="#swagger" id="swagger"></a>
 
-Visit `http://localhost:7145/swagger`. Decorated routes appear in the Swagger UI without manual annotation.
+Visit `http://localhost:7146/swagger`. Decorated routes appear in the Swagger UI without manual annotation. The generated spec itself is at `/swagger/openapi.json` (OpenAPI 3.0.3; set `TINA4_SWAGGER_OPENAPI=3.1` for 3.1.0).
 
 ```python
 from tina4_python import get
@@ -300,8 +315,10 @@ Looking at detailed [Usage](05-database.md) will deepen your understanding.
 tina4 migrate:create create_users_table
 ```
 
+Migration files are timestamp-prefixed, so they sort in creation order. Fill it in:
+
 ```sql
--- migrations/00001_create_users_table.sql
+-- migrations/20260812104512_create_users_table.sql
 CREATE TABLE users
 (
     id   INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -313,7 +330,7 @@ CREATE TABLE users
 tina4 migrate
 ```
 
-[Migrations](05-database.md) have limitations worth knowing before you use them at scale.
+More on writing and running them: [Migrations](05-database.md).
 
 ### ORM <a href="#orm" id="orm"></a>
 
@@ -330,21 +347,38 @@ user = User()
 user.load("id = ?", [1])
 ```
 
+The table has to exist first. Run a migration before the first `save()` -- [Databases](05-database.md) covers writing one.
+
 ORM covers more ground than this snippet shows. Study the [Advanced Detail](06-orm.md) to get the full value.
 
 ### CRUD <a href="#crud" id="crud"></a>
 
-```python
-from tina4_python import get
+Set `auto_crud` on a model and the framework registers the CRUD routes for it:
 
-@get("/users/dashboard")
-async def dashboard(request, response):
-    users = User().select("id, name, email")
-    return response.render("users/dashboard.twig", {"crud": users.to_crud(request)})
+```python
+from tina4_python.orm import ORM, IntegerField, StringField
+
+class User(ORM):
+    auto_crud = True
+
+    id   = IntegerField(primary_key=True, auto_increment=True)
+    name = StringField()
 ```
 
-```twig
-{{ crud }}
+On boot it logs `AutoCrud: registered 5 routes for User (/api/user)`:
+
+```
+GET    /api/user         list
+POST   /api/user         create
+GET    /api/user/{id}    read
+PUT    /api/user/{id}    update
+DELETE /api/user/{id}    delete
+```
+
+Or scaffold the files and edit them:
+
+```bash
+tina4 generate crud User
 ```
 
 [More details](19-scaffolding.md) on how CRUD generates its files and where they live.
@@ -363,13 +397,15 @@ print(result["body"])
 
 ### Inline Testing <a href="#inline-testing" id="inline-testing"></a>
 
+Each assertion is built from the *arguments* to call with and the expected result. Import all three names from `tina4_python.Testing`:
+
 ```python
-from tina4_python import tests
+from tina4_python.Testing import assert_equal, assert_raises, tests
 
 @tests(
-    expect_equal((7, 7), 1),
-    expect_equal((-1, 1), -1),
-    expect_raises(ZeroDivisionError, (5, 0)),
+    assert_equal((7, 7), 1),
+    assert_equal((-1, 1), -1),
+    assert_raises(ZeroDivisionError, (5, 0)),
 )
 def divide(a: int, b: int) -> float:
     if b == 0:
@@ -377,18 +413,41 @@ def divide(a: int, b: int) -> float:
     return a / b
 ```
 
-Run: `tina4 test`
+Run them with `tina4 test`. Add a test runner to the project first:
+
+```bash
+uv add pytest
+tina4 test
+```
 
 ### Services <a href="#services" id="services"></a>
 
-Due to the nature of Python, services are not necessary.
+Background work that outlives a request runs under the service runner, which starts each one in a background thread so the web server keeps serving. Use `register_service()` for a class-based service and `register()` for a callable:
+
+```python
+from tina4_python.service import Service, ServiceRunner
+
+class Heartbeat(Service):
+    def run(self):
+        while not self.should_stop():
+            ...
+
+runner = ServiceRunner()
+runner.register_service("heartbeat", Heartbeat())
+runner.register("cleanup", lambda ctx: purge_old_rows(), interval=300)
+runner.start()
+```
+
+[More details](27-service-runner.md) on the start/stop lifecycle and graceful shutdown.
 
 ### Websockets <a href="#websockets" id="websockets"></a>
 
 WebSocket support is built in. No extra dependencies. Define a handler with the `@websocket` decorator, and the framework manages the connection alongside your HTTP routes on the same port.
 
+Import `websocket` from `tina4_python.core.router`. Events are `open`, `message` and `close`.
+
 ```python
-from tina4_python import websocket
+from tina4_python.core.router import websocket
 
 @websocket("/ws/chat")
 async def chat_ws(connection, event, data):
@@ -409,8 +468,12 @@ from tina4_python.queue import Queue
 queue = Queue(topic="emails")
 queue.produce("emails", {"to": "alice@example.com", "subject": "Welcome"})
 
-# Consume messages
+# Consume messages - a worker loop, it does not return
 for job in queue.consume("emails"):
+    print(job.payload)
+
+# Drain a fixed number of times instead of looping forever
+for job in queue.consume("emails", iterations=1):
     print(job.payload)
 ```
 
@@ -418,10 +481,12 @@ for job in queue.consume("emails"):
 
 ### WSDL <a href="#wsdl" id="wsdl"></a>
 
-Subclass `WSDL` and decorate each operation with `@wsdl_operation`, giving the return shape. Drop the file in `src/routes/` and the framework serves the SOAP endpoint plus its generated WSDL.
+Subclass `WSDL` and decorate each operation with `@wsdl_operation`, giving the return shape. Hand the request to it from a route: `handle()` answers both the WSDL document (GET) and the SOAP call (POST).
 
 ```python
 from typing import List
+
+from tina4_python.core.router import get, noauth, post
 from tina4_python.wsdl import WSDL, wsdl_operation
 
 
@@ -434,34 +499,35 @@ class Calculator(WSDL):
     @wsdl_operation({"Numbers": List[int], "Total": int})
     def SumList(self, Numbers: List[int]):
         return {"Numbers": Numbers, "Total": sum(Numbers)}
+
+
+@get("/calculator")
+async def calculator_wsdl(request, response):
+    return response(Calculator(request).handle())
+
+
+@post("/calculator")
+@noauth()
+async def calculator_soap(request, response):
+    return response(Calculator(request).handle())
 ```
 
 [More Details](25-wsdl-soap.md) on WSDL configuration and usage.
 
 ### GraphQL <a href="#graphql" id="graphql"></a>
 
+`GraphQL()` takes no arguments. Build the schema on the instance: `add_type` for object types, `add_query` for a field plus its resolver. A resolver receives `(root, args, ctx)`.
+
 ```python
 from tina4_python.graphql import GraphQL
 
-schema = """
-type Query {
-    hello(name: String!): String
-    users: [User]
-}
+gql = GraphQL()
+gql.schema.add_type("User", {"id": "ID", "name": "String", "email": "String"})
+gql.schema.add_query("hello", {"name": "String!"}, "String",
+                     lambda root, args, ctx: f"Hello, {args['name']}!")
 
-type User {
-    id: Int
-    name: String
-    email: String
-}
-"""
-
-resolvers = {
-    "hello": lambda info, name: f"Hello, {name}!",
-    "users": lambda info: db.fetch("SELECT * FROM users").records,
-}
-
-graphql = GraphQL(schema, resolvers)
+gql.execute('{ hello(name: "Ada") }')
+# {'data': {'hello': 'Hello, Ada!'}}
 ```
 
 Register the endpoint:
@@ -472,11 +538,10 @@ from tina4_python import post, noauth
 @post("/graphql")
 @noauth()
 async def handle_graphql(request, response):
-    result = graphql.execute(request.body.get("query", ""))
-    return response(result)
+    return response(gql.execute(request.body.get("query", "")))
 ```
 
-GraphiQL UI available at `/__dev/graphql` in debug mode.
+`execute_json`, `introspect` and `schema_sdl` are also available, and `auto_register` generates a schema from your ORM models.
 
 ### Localization (i18n) <a href="#localization" id="localization"></a>
 
@@ -561,7 +626,7 @@ async def products(request, response):
 
 ### Health Endpoint <a href="#health" id="health"></a>
 
-Built-in at `/__health`, with `/health` always registered too. Returns `{"status": "ok", "version": "3.13.94", "uptime": 123.4, "framework": "tina4-python"}`. Configure the path with `TINA4_HEALTH_PATH`. It is a liveness probe: it reports on the process, never on a database or cache.
+Built-in at `/__health`, with `/health` always registered too. Returns `{"status": "ok", "version": "3.x.x", "uptime": 123.4, "framework": "tina4-python"}`. Configure the path with `TINA4_HEALTH_PATH`. It is a liveness probe: it reports on the process, never on a database or cache.
 
 ### DI Container <a href="#container" id="container"></a>
 
@@ -585,21 +650,32 @@ Available at `/__dev` in debug mode. Includes route inspector, database tab, req
 ### CLI Commands <a href="#cli" id="cli"></a>
 
 ```bash
-tina4 init python my-app    # Scaffold project
+tina4 setup                  # Guided setup: install what is missing, scaffold a project
+tina4 init python my-app     # Scaffold a project at a path you choose
 tina4 serve                  # Start dev server
 tina4 serve --production     # Production mode
 tina4 doctor                 # Check environment
 tina4 env                    # Configure .env
+tina4 scss                   # Compile src/scss/ to src/public/css/
 tina4 docs                   # Download documentation
 tina4 generate model User    # Generate scaffolding
 tina4 migrate                # Run migrations
 tina4 test                   # Run tests
 tina4 ai                     # Install AI context
+tina4 update                 # Self-update the CLI
 ```
 
 ### MCP Server <a href="#mcp" id="mcp"></a>
 
-Auto-starts on `/__mcp` in debug mode. Exposes 24 dev tools via JSON-RPC 2.0 over SSE. Works with Claude Code, Cursor, and other MCP clients.
+Mounted at `/__dev/mcp` in debug mode. Exposes 49 dev tools via JSON-RPC 2.0 -- `database_query`, `route_list`, `route_test` and friends. Works with Claude Code, Cursor, and other MCP clients.
+
+```bash
+curl -X POST http://localhost:7146/__dev/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Set `TINA4_MCP` to force it on or off; remote access additionally needs `TINA4_MCP_REMOTE=true` and a valid token.
 
 ### FakeData <a href="#fakedata" id="fakedata"></a>
 


### PR DESCRIPTION
Every section of `docs/python/index.md` was executed against tina4-python 3.13.98 (latest published) with CLI 3.8.67 and CPython 3.14.5, and the framework source read where a claim could not be exercised. The page keeps its structure and its section order — 38 headings before, 38 after, unchanged sequence. Only claims that disagreed with the framework changed.

## Snippets that could not run as printed

- **Websockets** imported `websocket` from `tina4_python`, which is the implementation module, not the decorator — `type(t.websocket)` is `module`. Now imported from `tina4_python.core.router`, with the three events named.
- **`GraphQL(schema, resolvers)`** cannot be constructed; `__init__(self)` takes no arguments. Replaced with the real builder API (`schema.add_type`, `schema.add_query`) and the `(root, args, ctx)` resolver signature, both confirmed in `graphql/__init__.py`.
- **CRUD called `to_crud()`**, which exists nowhere in the package. The real mechanism is `auto_crud` on the model, which registers five routes under `/api/<table>` (default prefix `/api`, table defaulting to the lowercased class name), or `tina4 generate crud`.
- **Middleware appended `str` to `response.content`**, which is declared `bytes` in `core/response.py`. A third `before_and_after_something` hook was shown running both before and after; only `before_*` and `after_*` are discovered prefixes, so it was removed along with the output comment it produced.
- **Static websites** claimed templates in `src/templates` are served with no configuration. `src/public` is what is served; a template needs a route, or `@template` below the route decorator — the decorator's own docstring says it must sit below, and gives a `.twig` example.
- **WSDL** claimed dropping the class in `src/routes/` serves the endpoint. The request has to be handed to it from a handler; `handle()` answers both the WSDL document and the SOAP call.
- **Inline testing** imported only `tests`, then used `expect_equal` and `expect_raises`. See the open question below.

## Wrong details

- **MCP** is mounted at `/__dev/mcp`, not `/__mcp`, and registers **49** tools, not 24 (counted in `mcp/tools.py`; identical on 3.13.94 and 3.13.98). Added the JSON-RPC request shape and the two env vars that gate it.
- **`RANDOM()` is not a Frond function**, so the form-token example rendered as a bare string. Simplified to `form_token()`, which the engine exposes both as a function and as a filter.
- **`migrate:create`** emits a timestamp-prefixed filename, not `00001_`.
- **The session backend table** omitted memcached and the four accepted aliases. Its handler speaks the memcached text protocol over a socket, so the Required package column is `--`, not a client library.
- **`TINA4_PORT=7145` and `localhost:7145`** are the PHP port; Python is 7146.
- **Services** said "Due to the nature of Python, services are not necessary", while Chapter 27 documents a service runner. Replaced with the real API: `register_service()` for a class-based service, `register()` for a callable.
- **The ORM section** did not say the table has to exist before the first `save()`.
- **`consume()`** is a worker loop that does not return; documented `iterations=` for draining a fixed number of times.
- **GraphiQL** was advertised at `/__dev/graphql`. No such route is registered in the package; claim dropped.
- **Installation** claimed the CLI "starts the server" and that "your browser opens" as one action. `init` scaffolds and installs, then asks `Start the server now? [Y/n]`; `serve` starts the server and opens the browser. Split accordingly, and the Homebrew tap plus `tina4 setup` added.
- **The CLI list** gained `tina4 setup`, `tina4 scss` and `tina4 update`, all three present in `tina4 --help`.
- **The Health section** quoted a body pinned to version 3.13.94, two releases stale. Shown as `3.x.x` now.
- **Hot Tips** gained the private-route-file rule.

## Verified facts the page was missing

Each read from the framework source: the generated spec is at `/swagger/openapi.json`, OpenAPI 3.0.3 by default with `TINA4_SWAGGER_OPENAPI=3.1` as the opt-in; an unauthenticated POST returns the 401 body quoted in Chapter 1's gotcha; AutoCrud logs `AutoCrud: registered 5 routes for User (/api/user)` on boot; `before_*` is for inspecting or rejecting and `after_*` for modifying the body; and the Environments section now links Chapter 33 for the full variable list.

## Chapter 1

Re-synced from tina4stack/tina4-book PR 152, keeping the two site-only differences this copy carries: the unprefixed title and the `<div v-pre>` wrapper around the Frond-syntax list. Both PRs should land together — the book is the source of truth for numbered chapters and `sync-books.sh` would otherwise overwrite this copy.

## One open question for the maintainers

The inline `@tests` builders were renamed `assert_*` → `expect_*` across the docs site in an earlier commit, citing issue 132. But `tina4_python.Testing` defines `assert_equal`, `assert_raises`, `assert_true`, `assert_false` and `tests` — and no `expect_*` — on **both 3.13.94 and 3.13.98**, so the snippet as printed raises `NameError` on every released version. This PR uses the names that exist.

**Correction to an earlier version of this description.** I first wrote that the other three backend languages carry the same rename. They do not. `10a1e3d` renamed `assertEqual` -> `expectEqual` in `docs/nodejs/18-testing.md`, `docs/nodejs/35-complete-app.md` and `docs/nodejs/index.md` — camelCase, and presumably correct for `tina4-nodejs` — and the same pass rewrote the snake_case names on `docs/python/index.md`. PHP and Ruby were never touched. So the question is narrower than I stated: was the Python page meant to follow a Node rename, or was it swept along? If it was meant to follow, revert this one section and land it with the release that ships `expect_*` in `tina4_python`.

Separately: `docs/python/18-testing.md` documents a different API — `from tina4_python.test import Test, assert_equal` with `(actual, expected, message)` — which is the pytest-style helper, not the `@tests` descriptor builder. The two are easy to confuse and neither page says so.

## Verification

`scripts/audit-truth.py` passes on this change: punctuation gate clean, and nothing this change introduces is flagged. The env-var check reports pre-existing references that only resolve when all four framework source trees are checked out alongside the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

