### PR TITLE
Release 3.13.103

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,14 @@ hero:
 
 <script src="/ask-hero.js" defer></script>
 
+## Current framework release: 3.13.103
+
+Python, PHP, Ruby, and Node.js are aligned on 3.13.103. This release makes the
+native Tina4 client the single owner of metrics, preserves Frond parity, and
+prevents a mismatched source version from reaching a package registry.
+
+[Read the release notes](/python/36-releases.md)
+
 ## Your AI doesn't know Tina4 yet. Give it 30 seconds.
 
 Copy this into Claude, Cursor, Copilot, or whatever you already have open. It reads the bootstrap protocol, installs what it needs, and hands you a running REST API with JWT auth. Same prompt, four languages.

--- a/docs/nodejs/36-releases.md
+++ b/docs/nodejs/36-releases.md
@@ -1,6 +1,28 @@
 # Release Notes
 
-## v3.13.101 (2026-08-14) - One AI client, four languages
+## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
+
+This release restores one public version across Python, PHP, Ruby, and Node.js.
+Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
+still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+
+### What changed
+
+- Dev-admin hands metrics work to the signed Tina4 client 3.8.76. Frameworks do
+  not keep a second metrics analyser or silently fall back to one.
+- `has_referencing_test` means that test source refers to the file. It does not
+  claim that the test ran, passed, or covered the file.
+- Frond expression parsing and evaluation are split into smaller internal steps,
+  while public APIs and the shared 84-case expression corpus remain unchanged.
+- Tina4 skills lead with `tina4 init` and `tina4 serve`, and keep scaffolding
+  prominent in every language.
+- Release workflows now reject a tag that differs from the source package
+  version before publishing.
+
+No runtime packages were added. Language extensions remain extensions, not
+framework dependencies.
+
++## v3.13.101 (2026-08-14) - One AI client, four languages
 
 One class. Three methods. No provider SDK.
 Tina4 applications can now call local models, OpenAI, and Anthropic through the

--- a/docs/php/36-releases.md
+++ b/docs/php/36-releases.md
@@ -1,6 +1,34 @@
 # Release Notes
 
-## v3.13.101 (2026-08-14) - One AI client, four languages
+## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
+
+This release restores one public version across Python, PHP, Ruby, and Node.js.
+Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
+still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+
+### What changed
+
+- Dev-admin hands metrics work to the signed Tina4 client 3.8.76. Frameworks do
+  not keep a second metrics analyser or silently fall back to one.
+- `has_referencing_test` means that test source refers to the file. It does not
+  claim that the test ran, passed, or covered the file.
+- Frond expression parsing and evaluation are split into smaller internal steps,
+  while public APIs and the shared 84-case expression corpus remain unchanged.
+- Tina4 skills lead with `tina4 init` and `tina4 serve`, and keep scaffolding
+  prominent in every language.
+- Release workflows now reject a tag that differs from the source package
+  version before publishing.
+
+No runtime packages were added. Language extensions remain extensions, not
+framework dependencies.
+
+### PHP connection timeout diagnosis
+
+PostgreSQL's explicit `timeout expired` result is now classified as the configured
+connection timeout at the clock boundary. Immediate connection refusals remain
+ordinary connection errors.
+
++## v3.13.101 (2026-08-14) - One AI client, four languages
 
 One class. Three methods. No provider SDK.
 Tina4 applications can now call local models, OpenAI, and Anthropic through the

--- a/docs/python/36-releases.md
+++ b/docs/python/36-releases.md
@@ -1,6 +1,28 @@
 # Release Notes
 
-## v3.13.101 (2026-08-14) - One AI client, four languages
+## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
+
+This release restores one public version across Python, PHP, Ruby, and Node.js.
+Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
+still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+
+### What changed
+
+- Dev-admin hands metrics work to the signed Tina4 client 3.8.76. Frameworks do
+  not keep a second metrics analyser or silently fall back to one.
+- `has_referencing_test` means that test source refers to the file. It does not
+  claim that the test ran, passed, or covered the file.
+- Frond expression parsing and evaluation are split into smaller internal steps,
+  while public APIs and the shared 84-case expression corpus remain unchanged.
+- Tina4 skills lead with `tina4 init` and `tina4 serve`, and keep scaffolding
+  prominent in every language.
+- Release workflows now reject a tag that differs from the source package
+  version before publishing.
+
+No runtime packages were added. Language extensions remain extensions, not
+framework dependencies.
+
++## v3.13.101 (2026-08-14) - One AI client, four languages
 
 One class. Three methods. No provider SDK.
 Tina4 applications can now call local models, OpenAI, and Anthropic through the

--- a/docs/ruby/36-releases.md
+++ b/docs/ruby/36-releases.md
@@ -1,6 +1,28 @@
 # Release Notes
 
-## v3.13.101 (2026-08-14) - One AI client, four languages
+## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
+
+This release restores one public version across Python, PHP, Ruby, and Node.js.
+Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
+still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+
+### What changed
+
+- Dev-admin hands metrics work to the signed Tina4 client 3.8.76. Frameworks do
+  not keep a second metrics analyser or silently fall back to one.
+- `has_referencing_test` means that test source refers to the file. It does not
+  claim that the test ran, passed, or covered the file.
+- Frond expression parsing and evaluation are split into smaller internal steps,
+  while public APIs and the shared 84-case expression corpus remain unchanged.
+- Tina4 skills lead with `tina4 init` and `tina4 serve`, and keep scaffolding
+  prominent in every language.
+- Release workflows now reject a tag that differs from the source package
+  version before publishing.
+
+No runtime packages were added. Language extensions remain extensions, not
+framework dependencies.
+
++## v3.13.101 (2026-08-14) - One AI client, four languages
 
 One class. Three methods. No provider SDK.
 Tina4 applications can now call local models, OpenAI, and Anthropic through the

--- a/plan/v3/release-3.13.103.md
+++ b/plan/v3/release-3.13.103.md
@@ -1,0 +1,55 @@
+# Task: Release Tina4 frameworks 3.13.103 at parity
+
+**Outcome:** Python, PHP, Ruby, and Node.js publish the same 3.13.103 release
+from tested v3 commits, with truthful runtime/package versions and release
+notes covering the native metrics contract and Frond maintenance work.
+
+## Scope
+
+- [x] Sweep open issues across the Tina4 organization before release.
+- [x] Verify full GitHub Actions suites are green on the current v3 heads.
+- [x] Audit the 3.13.102 tags and public registries.
+- [x] Cut fresh `feature/release3.13.103` branches from v3.
+- [x] Bump every runtime, package, lockfile, guide, and version assertion.
+- [x] Add 3.13.103 changelog entries in all four frameworks.
+- [x] Add the release notes to all four documentation and book editions,
+      plus the documentation landing page.
+- [x] Add publish guards that reject a tag/source version mismatch.
+- [ ] Build the four distributable artifacts and verify embedded versions.
+- [ ] Merge release PRs into v3 and verify the exact merge heads.
+- [ ] Tag 3.13.103, wait for all publish workflows, and verify registries.
+- [ ] Delete the release branches and record final release commits.
+
+## Parity
+
+| Release property | Python | PHP | Ruby | Node.js |
+| --- | --- | --- | --- | --- |
+| Source version 3.13.103 | ✅ | ✅ | ✅ | ✅ |
+| Changelog present | ✅ | ✅ | ✅ | ✅ |
+| Tag/source guard | ✅ | ✅ | ✅ | ✅ |
+| Full suite green | ✅ | ✅ | ✅ | ✅ |
+| Public registry 3.13.103 | ⏳ | ⏳ | ⏳ | ⏳ |
+
+## Tests
+
+- [ ] Existing version-contract suites pass in all four frameworks.
+- [ ] Python wheel metadata and runtime report 3.13.103.
+- [ ] PHP runtime reports 3.13.103 and Composer validates the package.
+- [ ] Both Ruby gems build as 3.13.103.
+- [ ] Node tarball metadata reports 3.13.103.
+- [ ] Documentation and book audits pass with matching release notes.
+- [ ] Publish workflows fail before registry mutation when tag and source differ.
+- [ ] Post-merge v3 workflows pass at the tagged commits.
+
+## Bugs
+
+- [x] RELEASE-102-RUBY: tag 3.13.102 built 3.13.101 and RubyGems rejected it.
+- [x] RELEASE-102-NODE: tag 3.13.102 built 3.13.101 and npm rejected it.
+- [x] RELEASE-VERSION-GUARD: publish workflows do not uniformly prove the tag
+      matches the source package/runtime version before publishing.
+
+## Commits
+
+- Pending.
+
+## Status: In progress

--- a/plan/v3/release-3.13.103.md
+++ b/plan/v3/release-3.13.103.md
@@ -15,7 +15,7 @@ notes covering the native metrics contract and Frond maintenance work.
 - [x] Add the release notes to all four documentation and book editions,
       plus the documentation landing page.
 - [x] Add publish guards that reject a tag/source version mismatch.
-- [ ] Build the four distributable artifacts and verify embedded versions.
+- [x] Build the four distributable artifacts and verify embedded versions.
 - [ ] Merge release PRs into v3 and verify the exact merge heads.
 - [ ] Tag 3.13.103, wait for all publish workflows, and verify registries.
 - [ ] Delete the release branches and record final release commits.
@@ -32,13 +32,13 @@ notes covering the native metrics contract and Frond maintenance work.
 
 ## Tests
 
-- [ ] Existing version-contract suites pass in all four frameworks.
-- [ ] Python wheel metadata and runtime report 3.13.103.
-- [ ] PHP runtime reports 3.13.103 and Composer validates the package.
-- [ ] Both Ruby gems build as 3.13.103.
-- [ ] Node tarball metadata reports 3.13.103.
-- [ ] Documentation and book audits pass with matching release notes.
-- [ ] Publish workflows fail before registry mutation when tag and source differ.
+- [x] Existing version-contract suites pass in all four frameworks.
+- [x] Python wheel metadata and runtime report 3.13.103.
+- [x] PHP runtime reports 3.13.103 and Composer validates the package.
+- [x] Both Ruby gems build as 3.13.103.
+- [x] Node tarball metadata reports 3.13.103.
+- [x] Documentation and book audits pass with matching release notes.
+- [x] Publish workflows fail before registry mutation when tag and source differ.
 - [ ] Post-merge v3 workflows pass at the tagged commits.
 
 ## Bugs
@@ -48,8 +48,28 @@ notes covering the native metrics contract and Frond maintenance work.
 - [x] RELEASE-VERSION-GUARD: publish workflows do not uniformly prove the tag
       matches the source package/runtime version before publishing.
 
+## Lab evidence
+
+The canonical isolated runner completed as root on
+`andre@192.168.88.99` against the exact release commits after updating the
+signed native client from 3.8.71 to 3.8.76:
+
+- Python: 5,527 passed.
+- PHP: 5,444 tests and 19,094 assertions.
+- Ruby: 5,449 examples and 0 failures.
+- Node.js: 8,436 passed and 0 skipped.
+- Documentation: 10 audit tests passed, 2 environment-specific tests skipped,
+  276 Markdown files passed strict link and anchor checks, and all 135 feature
+  entries aligned.
+- Book: the JavaScript reference build reproduced byte for byte.
+
 ## Commits
 
-- Pending.
+- Python: `81f3d566977b41a2c9a9186151966a3e21866ca5`
+- PHP: `4546f0b6a9c782fe378a2ac7bb2e2406fb9dd2e9`
+- Ruby: `306274e23abb02cb88843e8d9875487a60f2e364`
+- Node.js: `38541c021653bd34f4b726fe8aeb7d3a2fb6c61b`
+- Documentation: `75df822` (release evidence update pending)
+- Book: `0628094`
 
-## Status: In progress
+## Status: Lab green; awaiting merge and registry publication


### PR DESCRIPTION
## 3.13.103 release documentation\n\n- publishes truthful release notes in all four language editions\n- records the 3.13.102 registry split and directs users to 3.13.103\n- documents native metrics semantics and the signed client requirement\n- records full root lab evidence and package preflight\n\nDocumentation audit: 10 passed, 2 environment-specific skipped; 276 Markdown files passed strict link and anchor checks; 135 feature entries aligned.\n\nCo-Authored-By: Tina4 <82961293+tina4stack@users.noreply.github.com>