### PR TITLE
docs: align tina4-js clean URLs and What's New

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,6 +106,10 @@ A lightweight, read-only desktop reviewer that understands your Tina4 layout, le
 
 **v3.13.101 (2026-08-14)** - [full notes](/python/36-releases.md)
 
+One AI client across all four backends. Applications can call local models, OpenAI, and Anthropic through the same three operations: chat, complete, and embed. Streaming returns ordered text deltas; timeouts and retries are bounded; failures do not expose keys, prompts, or provider response bodies. The client uses each language's built-in HTTP support, so it adds no runtime package dependency. This release also moves code-health analysis fully into the native `tina4 metrics` command while the dev dashboard consumes its JSON output.
+
+**v3.13.100 (2026-08-14)** - [full notes](/python/36-releases.md)
+
 Frond keeps the whole page. A second `{% extends %}` now fails with a clear error, nested root blocks keep their content, and Ruby resolves multi-level inheritance without recursing through the same child. Bounded template, fragment, and expression caches stop long-running workers from collecting stale entries. Skill downloads retry transient failures, and release-version guards now keep every package and guide on the same number.
 
 **v3.13.99 (2026-08-13)** - [full notes](/python/36-releases.md)

--- a/docs/js/01-getting-started.md
+++ b/docs/js/01-getting-started.md
@@ -174,7 +174,7 @@ import './routes/index';
 // api.configure({ baseUrl: '/api', auth: true });
 
 // Start router
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 Three things happen here:
@@ -183,7 +183,7 @@ Three things happen here:
 2. **Import your routes.** The route file calls `route()` to register paths and handlers.
 3. **Start the router.** It finds `#root` in the DOM and renders matched routes into it.
 
-The `mode: 'hash'` means URLs look like `http://localhost:5173/#/about`. For clean URLs without the hash, use `mode: 'history'` -- but you will need server-side URL rewriting in production.
+History mode is canonical and gives clean URLs such as `http://localhost:5173/about`. Your production server must return `index.html` for unknown application paths. Use `mode: 'hash'` only when a static host cannot provide that fallback. In either mode, links and `navigate()` use a bare path such as `/about`; never add the hash yourself.
 
 ---
 

--- a/docs/js/04-components.md
+++ b/docs/js/04-components.md
@@ -554,7 +554,7 @@ import { router } from 'tina4js';
 // Every file under src/components/ is imported, so every tag is defined.
 import.meta.glob('./components/*.ts', { eager: true });
 
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 Add `src/components/user-card.ts` and `<user-card>` works on the next reload. No list to update.

--- a/docs/js/05-routing.md
+++ b/docs/js/05-routing.md
@@ -183,12 +183,12 @@ Two options:
 
 | Mode | URLs | Requires |
 |---|---|---|
-| `'history'` | `/about`, `/users/42` | Server-side URL rewriting |
-| `'hash'` | `/#/about`, `/#/users/42` | Nothing -- works everywhere |
+| `'history'` | `/about`, `/users/42` | Server-side `index.html` fallback |
+| `'hash'` | `/#/about`, `/#/users/42` | Nothing -- static-host fallback |
 
-**Hash mode** is the default in scaffolded projects. URLs carry a `#` prefix. No server configuration needed. Works on static hosts, GitHub Pages, S3, anywhere you can drop files.
+**History mode** is canonical and is used by scaffolded projects. It gives clean URLs without the hash. The server must return `index.html` for application routes. When a user bookmarks `https://myapp.com/users/42` and loads it, the server needs to serve the SPA -- not search for a `/users/42` file that does not exist.
 
-**History mode** gives clean URLs without the hash. But the server must return `index.html` for all routes. When a user bookmarks `https://myapp.com/users/42` and loads it, the server needs to serve the SPA -- not search for a `/users/42` file that does not exist.
+**Hash mode** is the fallback for static hosts that cannot rewrite unknown paths. URLs carry a `#` prefix, but application code still passes bare paths such as `/users/42` to links and `navigate()`. Never add the hash yourself.
 
 Vite dev server handles this automatically. For production, configure your web server:
 
@@ -471,7 +471,7 @@ route('*', () => html`
 import { router } from 'tina4js';
 import './routes/index';
 
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 ---
@@ -497,7 +497,7 @@ import { router } from 'tina4js';
 // Every file under src/routes/ is imported, so every route registers.
 import.meta.glob('./routes/*.ts', { eager: true });
 
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 This works because `route()` registers on import. Calling it appends to the router's table as the module body runs, so importing the file *is* registering its routes. There is no registry to populate and no return value to collect. Drop in `src/routes/reports.ts`, reload, and its routes are live.
@@ -525,7 +525,7 @@ import.meta.glob('./routes/*.ts', { eager: true });   // no 404 file in here
 
 route('*', () => html`<h1>404</h1><a href="/">Go home</a>`);
 
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 Renaming the file so it sorts last works too, and breaks the day someone renames it back. Keep the catch-all out of the folder.

--- a/docs/js/13-backend-integration.md
+++ b/docs/js/13-backend-integration.md
@@ -77,7 +77,7 @@ api.configure({
   auth: true,
 });
 
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 Now `api.get('/users')` hits `http://localhost:7145/api/users` during development. The Vite proxy handles the forwarding. The browser sees a same-origin request. No CORS headers needed.

--- a/docs/js/14-building-a-complete-app.md
+++ b/docs/js/14-building-a-complete-app.md
@@ -126,7 +126,7 @@ pwa.register({
 });
 
 // Start router
-router.start({ target: '#root', mode: 'hash' });
+router.start({ target: '#root', mode: 'history' });
 ```
 
 The entry point is the wiring diagram. API configured. Interceptor registered. PWA enabled. Debug overlay loaded in development. Router started. Every cross-cutting concern lives here, declared once, applied everywhere.


### PR DESCRIPTION
## Summary

- make history-mode clean URLs canonical in tina4-js documentation
- retain hash routing as the explicit static-host fallback
- correct the landing-page entries for releases 3.13.100 and 3.13.101

## Verification

- tina4press built all 276 pages
- landing-page release freshness audit passed
- markdown diff check passed