### PR TITLE
docs: correct 3.13.102 release facts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ A lightweight, read-only desktop reviewer that understands your Tina4 layout, le
 
 **v3.13.103 (2026-08-16)** - [full notes](/python/36-releases.md)
 
-Metrics you can trust, and releases that cannot lie. This release restores one public version across Python, PHP, Ruby, and Node.js; skip 3.13.102, whose RubyGems and npm packages still contained 3.13.101. Dev-admin now hands code-health analysis to the signed Tina4 client, `has_referencing_test` means exactly that a test refers to the source file, and release workflows reject tags that disagree with package versions. Tina4 skills lead with `tina4 init` and `tina4 serve`. No runtime packages were added; language extensions remain extensions, not dependencies.
+Metrics you can trust, and releases that cannot lie. Version 3.13.102 was a skills-only release, so framework runtime packages correctly remained at 3.13.101. Version 3.13.103 is the next framework release. Dev-admin now hands code-health analysis to the signed Tina4 client, `has_referencing_test` means exactly that a test refers to the source file, and framework release workflows reject tags that disagree with package versions. Tina4 skills lead with `tina4 init` and `tina4 serve`. No runtime packages were added; language extensions remain extensions, not dependencies.
 
 **v3.13.101 (2026-08-14)** - [full notes](/python/36-releases.md)
 

--- a/docs/nodejs/36-releases.md
+++ b/docs/nodejs/36-releases.md
@@ -2,9 +2,9 @@
 
 ## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
 
-This release restores one public version across Python, PHP, Ruby, and Node.js.
-Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
-still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+Version 3.13.102 was a skills-only release, so framework runtime packages
+correctly remained at 3.13.101. Version 3.13.103 is the next framework release
+and carries the metrics and release-hardening changes below.
 
 ### What changed
 

--- a/docs/php/36-releases.md
+++ b/docs/php/36-releases.md
@@ -2,9 +2,9 @@
 
 ## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
 
-This release restores one public version across Python, PHP, Ruby, and Node.js.
-Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
-still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+Version 3.13.102 was a skills-only release, so framework runtime packages
+correctly remained at 3.13.101. Version 3.13.103 is the next framework release
+and carries the metrics and release-hardening changes below.
 
 ### What changed
 

--- a/docs/python/36-releases.md
+++ b/docs/python/36-releases.md
@@ -2,9 +2,9 @@
 
 ## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
 
-This release restores one public version across Python, PHP, Ruby, and Node.js.
-Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
-still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+Version 3.13.102 was a skills-only release, so framework runtime packages
+correctly remained at 3.13.101. Version 3.13.103 is the next framework release
+and carries the metrics and release-hardening changes below.
 
 ### What changed
 

--- a/docs/ruby/36-releases.md
+++ b/docs/ruby/36-releases.md
@@ -2,9 +2,9 @@
 
 ## v3.13.103 (2026-08-16) - Metrics you can trust, releases that cannot lie
 
-This release restores one public version across Python, PHP, Ruby, and Node.js.
-Version 3.13.102 reached PyPI and Packagist, but its RubyGems and npm packages
-still contained 3.13.101. Skip 3.13.102 and upgrade to 3.13.103.
+Version 3.13.102 was a skills-only release, so framework runtime packages
+correctly remained at 3.13.101. Version 3.13.103 is the next framework release
+and carries the metrics and release-hardening changes below.
 
 ### What changed
 

--- a/plan/v3/release-3.13.103.md
+++ b/plan/v3/release-3.13.103.md
@@ -43,8 +43,7 @@ notes covering the native metrics contract and Frond maintenance work.
 
 ## Bugs
 
-- [x] RELEASE-102-RUBY: tag 3.13.102 built 3.13.101 and RubyGems rejected it.
-- [x] RELEASE-102-NODE: tag 3.13.102 built 3.13.101 and npm rejected it.
+- [x] RELEASE-102-SKILLS: 3.13.102 was a skills-only release; framework runtime packages correctly remained at 3.13.101.
 - [x] RELEASE-VERSION-GUARD: publish workflows do not uniformly prove the tag
       matches the source package/runtime version before publishing.
 - [x] RELEASE-103-NODE-PUBLISH: Node 22/npm 10 rejected optional Vitest/esbuild


### PR DESCRIPTION
## Correction

3.13.102 was a skills-only release. Framework packages remaining at 3.13.101 was intentional, not a failed package release.

This corrects the landing page, all four 3.13.103 release-note editions, and the internal release record.

## Verification

- landing-page freshness audit passed
- tina4press built all 276 pages
- markdown diff check passed