### PR TITLE
Document the 3.13.104 metrics baseline

### DIFF
--- a/docs/general/cli.md
+++ b/docs/general/cli.md
@@ -1,305 +1,167 @@
-# Tina4 CLI Reference
+# Tina4 CLI reference
 
-The Tina4 CLI is a single binary that manages all four backend languages. It detects your project language, manages runtimes, compiles SCSS, watches files for dev-reload, and delegates to the language-specific CLI.
+The Tina4 client is one signed binary for Python, PHP, Ruby, Node.js, and
+tina4-js. It creates projects, starts servers, manages local tooling, and
+measures source code without loading a framework runtime.
 
-## Installation
+## Install the client
 
-**macOS (Homebrew):**
-
-```bash
-brew install tina4stack/tap/tina4
-```
-
-**Linux / macOS (install script):**
+macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tina4stack/tina4/main/install.sh | bash
+curl -fsSL https://tina4.com/install.sh | sh
 ```
 
-**Windows (PowerShell):**
+Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/tina4stack/tina4/main/install.ps1 | iex
+irm https://tina4.com/install.ps1 | iex
 ```
 
-Verify:
+Check the installed version:
 
 ```bash
 tina4 --version
 ```
 
----
+## Command map
 
-All available commands:
+| Command | Purpose |
+| --- | --- |
+| `tina4 setup` | Run guided setup and create a ready-to-run project. |
+| `tina4 init` | Create a project for Python, PHP, Ruby, Node.js, or tina4-js. |
+| `tina4 serve` | Start the detected framework with file watching and SCSS compilation. |
+| `tina4 doctor` | Report installed runtimes, package managers, and Tina4 tools. |
+| `tina4 install` | Install a supported language runtime. |
+| `tina4 scss` | Compile SCSS into CSS. |
+| `tina4 build` | Build production front-end assets. |
+| `tina4 deploy` | Generate Docker, systemd, nginx, or cPanel deployment files. |
+| `tina4 env` | Inspect, migrate, and synchronize environment variables. |
+| `tina4 metrics` | Measure production source and rank code-health findings. |
+| `tina4 ai` | Detect coding assistants and install Tina4 context. |
+| `tina4 skills` | Install current Tina4 skills for Claude, Codex, Cursor, or all three. |
+| `tina4 docs` | Download framework documentation into `.tina4-docs/`. |
+| `tina4 books` | Download the matching Tina4 book. |
+| `tina4 agent` | Start the Code With Me agent server. |
+| `tina4 update` | Update the signed client and refresh installed skills. |
 
-```
-Usage: tina4 <COMMAND>
+Run `tina4 <command> --help` for the command's current arguments and options.
 
-Commands:
-  doctor    Check installed languages and tools
-  install   Install a language runtime (python, php, ruby, nodejs)
-  init      Scaffold a new Tina4 project: tina4 init <language> <path>
-  serve     Start the server with file watcher and SCSS compilation
-  scss      Compile SCSS files from src/scss/ to src/public/css/
-  migrate   Run database migrations (delegates to language CLI)
-  test      Run tests (delegates to language CLI)
-  routes    List registered routes (delegates to language CLI)
-  generate  Generate scaffolding: model, route, migration, middleware
-  ai        Detect AI coding tools and install framework context/skills
-  upgrade   Upgrade a v2 Tina4 project to v3 structure
-  update    Self-update the tina4 binary
-  books     Download the Tina4 book into the current directory
-```
+## Start a project
 
-## Commands
-
-### tina4 doctor
-
-Check which languages and tools are installed on your machine.
+One command creates the project. One command runs it.
 
 ```bash
+tina4 init python my-app
+cd my-app
+tina4 serve
+```
+
+Replace `python` with `php`, `ruby`, `nodejs`, or `js`. The `js` option creates
+a tina4-js front-end project.
+
+`tina4 serve` detects the framework from the project files. You can also name a
+configured project from another directory:
+
+```bash
+tina4 serve my-app
+```
+
+Common server options:
+
+| Option | Purpose |
+| --- | --- |
+| `-p, --port <PORT>` | Override the framework's default port. |
+| `--host <HOST>` | Bind to another address. The default is `0.0.0.0`. |
+| `--dev` | Force the development server. |
+| `--production` | Install and use the preferred production server. |
+| `--no-browser` | Do not open a browser after startup. |
+| `--no-reload` | Disable the file watcher's reload signal. |
+
+## Measure code health
+
+`tina4 metrics` reads source files directly. It does not start the application
+or import the framework. One native engine applies the same formulas to Python,
+PHP, Ruby, TypeScript/JavaScript, and Rust.
+
+Run it from a project:
+
+```bash
+tina4 metrics
+```
+
+Scan an explicit source directory and show the ten highest-ranked findings:
+
+```bash
+tina4 metrics --path src --top 10
+```
+
+The report measures lines of code, cyclomatic complexity, maintainability,
+coupling, function count, duplicate blocks, and test-reference evidence. It
+reports evidence that a test refers to a source file. It does not claim that
+the test ran, passed, or covered each branch.
+
+### Metrics options
+
+| Option | Purpose |
+| --- | --- |
+| `--path <PATH>` | Scan one directory or file. Without it, the client detects the source root. |
+| `--top <N>` | Limit the displayed ranked list. The default is 20. Totals stay unchanged. |
+| `--json` | Emit the machine contract used by dev-admin and CI. |
+| `--fail-on warn` | Exit with code 1 for warning or error findings. |
+| `--fail-on error` | Exit with code 1 for error findings. |
+| `--exclude <GLOB>` | Exclude a path. Repeat the option for more paths. |
+| `--include-non-production` | Include tests, specs, and declaration files. |
+
+Production scans ignore conventional tests, specs, generated bundles, minified
+assets, declarations, dependencies, build output, caches, and version-control
+data. Use explicit exclusions for project-specific production trees:
+
+```bash
+tina4 metrics --exclude '**/dev_admin/**' --exclude '**/gallery/**'
+```
+
+### CI gate
+
+Use JSON for stored reports and `--fail-on` for the gate:
+
+```bash
+tina4 metrics --json --fail-on error > metrics.json
+```
+
+`--top` changes presentation only. It never hides a finding from the exit gate.
+Informational `no_test_reference` findings do not fail warning or error gates.
+
+### Reading offender totals
+
+An offender is one finding, not one file. A file can carry several findings:
+high function complexity, excessive size, low maintainability, duplication, and
+too many functions. Count unique file names when you need the size of the
+refactoring worklist. Count findings when you need the gate pressure.
+
+## Manage environment variables
+
+The client can list the variables that source code uses, generate
+`.env.example`, synchronize missing entries, and migrate legacy unprefixed
+names.
+
+```bash
+tina4 env --list
+tina4 env --example
+tina4 env --sync
+tina4 env --migrate
+```
+
+Migration creates `.env.bak` before it writes the canonical `TINA4_*` names.
+Use `--yes` to skip confirmation in CI.
+
+## Keep tools current
+
+```bash
+tina4 update
+tina4 skills all
 tina4 doctor
 ```
 
-Example output:
-
-```
-Tina4 Doctor - Environment Check
-
-  Language     Status     Version              Pkg Mgr      Version
-  ──────────────────────────────────────────────────────────────────────
-  Python       ✓          3.13.5               ✓ uv         0.8.19
-  PHP          ✓          8.5.4                ✓ composer   2.9.5
-  Ruby         ✓          4.0.1                ✓ bundler    4.0.8
-  Node.js      ✓          24.9.0               ✓ npm        11.6.0
-
-  Tina4 CLIs
-  ──────────────────────────────────────────────────────────────────────
-  ✓ tina4python      Python       installed
-  ✓ tina4php         PHP          installed
-  ✓ tina4ruby        Ruby         installed
-  ✓ tina4nodejs      Node.js      installed
-```
-
-Shows installed languages, their versions, package managers, and whether the language-specific Tina4 CLIs are available.
-
----
-
-### tina4 install
-
-Install a language runtime.
-
-```bash
-tina4 install <language>
-```
-
-| Argument | Description |
-|----------|-------------|
-| `python` | Install Python runtime |
-| `php` | Install PHP runtime |
-| `ruby` | Install Ruby runtime |
-| `nodejs` | Install Node.js runtime |
-
----
-
-### tina4 init
-
-Scaffold a new Tina4 project.
-
-```bash
-tina4 init <language> <path>
-```
-
-| Argument | Description |
-|----------|-------------|
-| `language` | `python`, `php`, `ruby`, or `nodejs` |
-| `path` | Project directory (absolute or relative) |
-
-Creates the standard Tina4 project structure:
-
-```
-my-app/
-  src/
-    routes/        # Route handlers
-    orm/           # ORM models
-    templates/     # Twig templates
-    public/        # Static files (CSS, JS, images)
-    scss/          # SCSS source files
-  migrations/      # Database migration files
-  .env             # Environment variables
-```
-
----
-
-### tina4 serve
-
-Start the development server with file watcher and SCSS compilation.
-
-```bash
-tina4 serve [options]
-```
-
-| Option | Description |
-|--------|-------------|
-| `-p, --port <PORT>` | Port number. Defaults: Python 7145, PHP 7146, Ruby 7147, Node.js 7148 |
-| `--host <HOST>` | Host address (default: 0.0.0.0) |
-| `--dev` | Force dev server even if a production server is available |
-| `--production` | Install and use the best production server for the detected language |
-
-The CLI auto-detects your project language from the project files. It watches for file changes, recompiles SCSS, and reloads the server.
-
-Production servers per language:
-- **Python**: Hypercorn (ASGI)
-- **PHP**: Tina4's built-in server
-- **Ruby**: Puma
-- **Node.js**: Node's built-in HTTP server
-
----
-
-### tina4 scss
-
-Compile SCSS files to CSS.
-
-```bash
-tina4 scss [options]
-```
-
-| Option | Description |
-|--------|-------------|
-| `-i, --input <DIR>` | Input directory (default: `src/scss`) |
-| `-o, --output <DIR>` | Output directory (default: `src/public/css`) |
-| `-m, --minify` | Minify the output |
-| `-w, --watch` | Watch for changes and recompile |
-
----
-
-### tina4 migrate
-
-Run database migrations. Delegates to the language-specific CLI.
-
-```bash
-tina4 migrate                          # Run pending migrations
-tina4 migrate --create <description>   # Create a new migration file
-```
-
-| Option | Description |
-|--------|-------------|
-| `--create <NAME>` | Create a new migration file with this description |
-
-Migration files are created in the `migrations/` directory with sequential numbering.
-
----
-
-### tina4 test
-
-Run tests. Delegates to the language-specific CLI.
-
-```bash
-tina4 test
-```
-
----
-
-### tina4 routes
-
-List all registered routes. Delegates to the language-specific CLI.
-
-```bash
-tina4 routes
-```
-
-Shows the HTTP method, path, and handler for every route in your project.
-
----
-
-### tina4 generate
-
-Generate scaffolding for common project components.
-
-```bash
-tina4 generate <what> <name>
-```
-
-| Argument | Description |
-|----------|-------------|
-| `model` | Generate an ORM model class |
-| `route` | Generate a route file |
-| `migration` | Generate a migration file |
-| `middleware` | Generate a middleware class |
-
-Examples:
-
-```bash
-tina4 generate model User
-tina4 generate route api/products
-tina4 generate migration create_users_table
-tina4 generate middleware AuthCheck
-```
-
----
-
-### tina4 ai
-
-Detect AI coding tools and install framework context files.
-
-```bash
-tina4 ai [options]
-```
-
-| Option | Description |
-|--------|-------------|
-| `--all` | Install context for ALL known AI tools (not just detected ones) |
-| `--force` | Overwrite existing context files |
-
-This detects tools like Claude Code, Cursor, GitHub Copilot, and installs CLAUDE.md, .cursorrules, or other context files that help AI assistants understand your Tina4 project.
-
----
-
-### tina4 update
-
-Upgrade a v2 Tina4 project to the v3 structure.
-
-```bash
-tina4 update
-```
-
-Restructures your project to follow the v3 conventions (src/routes, src/orm, src/templates, etc.).
-
----
-
-### tina4 update
-
-Self-update the tina4 binary to the latest version.
-
-```bash
-tina4 update
-```
-
----
-
-### tina4 books
-
-Download the Tina4 book into the current directory.
-
-```bash
-tina4 books
-```
-
-Downloads the complete documentation book for your detected language.
-
----
-
-## Environment Variables
-
-The `.env` file in your project root configures the framework:
-
-```bash
-PROJECT_NAME="My Project"
-VERSION=1.0.0
-TINA4_LOG_LEVEL=ALL
-DATABASE_NAME=sqlite3:data.db
-TINA4_SECRET=your-secret-key
-TINA4_LOCALE=en
-```
-
-All Tina4 frameworks read from the same `.env` format. The `tina4 init` command creates a default `.env` with sensible values.
+The update command refreshes the signed binary and installed Tina4 skills. The
+doctor command then shows which runtimes and framework clients are ready.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ layout: home
 hero:
   name: "Tina4"
   text: "Documentation"
-  tagline: One framework, four languages, ninety-seven features, zero runtime dependencies.
+  tagline: One framework, four languages, 137 features, zero runtime dependencies.
   image:
     src: '/images/tina4-animated.svg'
   actions:
@@ -50,11 +50,11 @@ hero:
 
 <script src="/ask-hero.js" defer></script>
 
-## Current framework release: 3.13.103
+## Current framework release: 3.13.104
 
-Python, PHP, Ruby, and Node.js are aligned on 3.13.103. This release makes the
-native Tina4 client the single owner of metrics, preserves Frond parity, and
-prevents a mismatched source version from reaching a package registry.
+Python, PHP, Ruby, and Node.js are aligned on 3.13.104. This release adds GIS
+point support and provider-neutral OpenID Connect SSO. Both features follow one
+configuration-first contract across all four frameworks.
 
 [Read the release notes](/python/36-releases.md)
 
@@ -111,6 +111,16 @@ A lightweight, read-only desktop reviewer that understands your Tina4 layout, le
 :::
 
 ## What's new
+
+**v3.13.104 (2026-08-17)** - [full notes](/python/36-releases.md)
+
+GIS points now store longitude-first coordinates in PostGIS, build GiST
+indexes, calculate distances in metres, and return GeoJSON. Configuration-first
+SSO adds OpenID Connect discovery, Authorization Code with PKCE, Session
+handoff, refresh, logout, secured-route identity, and Swagger integration. The
+runtime stays provider-neutral. The documentation includes Keycloak as an
+implementation example, not as a framework requirement. No runtime package
+dependency was added.
 
 **v3.13.103 (2026-08-16)** - [full notes](/python/36-releases.md)
 

--- a/docs/nodejs/36-releases.md
+++ b/docs/nodejs/36-releases.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v3.13.104 - GIS and configuration-first SSO
+## v3.13.104 (2026-08-17) - GIS and configuration-first SSO
 
 - `Point` and `type: "point"` fields add PostGIS-first point storage, metre-based distance queries, GiST indexes, and GeoJSON output. Tina4 uses longitude-first coordinates and fails clearly on unsupported engines.
 - `Sso` adds provider-neutral OpenID Connect discovery, Authorization Code with PKCE, introspection, Session handoff, refresh, logout, and automatic `/auth/*` routes.

--- a/docs/php/36-releases.md
+++ b/docs/php/36-releases.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v3.13.104 - GIS and configuration-first SSO
+## v3.13.104 (2026-08-17) - GIS and configuration-first SSO
 
 - `Point` and model `pointFields` add PostGIS-first point storage, metre-based distance queries, GiST indexes, and GeoJSON output. Tina4 uses longitude-first coordinates and fails clearly on unsupported engines.
 - `Sso` adds provider-neutral OpenID Connect discovery, Authorization Code with PKCE, introspection, Session handoff, refresh, logout, and automatic `/auth/*` routes.

--- a/docs/python/36-releases.md
+++ b/docs/python/36-releases.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v3.13.104 - GIS and configuration-first SSO
+## v3.13.104 (2026-08-17) - GIS and configuration-first SSO
 
 - `Point` and `PointField` add PostGIS-first point storage, metre-based distance queries, GiST indexes, and GeoJSON output. Tina4 uses longitude-first coordinates and fails clearly on unsupported engines.
 - `Sso` adds provider-neutral OpenID Connect discovery, Authorization Code with PKCE, introspection, Session handoff, refresh, logout, and automatic `/auth/*` routes.

--- a/docs/ruby/36-releases.md
+++ b/docs/ruby/36-releases.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v3.13.104 - GIS and configuration-first SSO
+## v3.13.104 (2026-08-17) - GIS and configuration-first SSO
 
 - `Tina4::Point` and `point_field` add PostGIS-first point storage, metre-based distance queries, GiST indexes, and GeoJSON output. Tina4 uses longitude-first coordinates and fails clearly on unsupported engines.
 - `Tina4::Sso` adds provider-neutral OpenID Connect discovery, Authorization Code with PKCE, introspection, Session handoff, refresh, logout, and automatic `/auth/*` routes.

--- a/plan/v3/features/121-cli-metrics.md
+++ b/plan/v3/features/121-cli-metrics.md
@@ -3,8 +3,8 @@
 ## Identity and status
 
 - Matrix identity: 121 — CLI code metrics
-- Audit state: implementation-ready; approved decisions are implemented and awaiting release integration
-- Audit note: remeasured 2026-08-16 with a rebuilt native client against Python, PHP, Ruby, Node.js, and tina4-js. Every corpus completed with zero parse refusals.
+- Audit state: released in Tina4 client 3.8.76; framework consumers released in 3.13.104
+- Audit note: remeasured 2026-08-17 on the Linux lab against released Python, PHP, Ruby, and Node.js 3.13.104 source. Every corpus completed with zero parse refusals.
 - Dependencies: tree-sitter and supported grammar crates compiled into the Tina4 client. Language runtimes and extensions are not dependencies.
 - Dependants: developers, CI gates, dev-admin, and tools that consume JSON.
 - Decisions: ADR-0002, ADR-0054, and ADR-0055.
@@ -35,6 +35,12 @@ Those adapters run `tina4 metrics --json`; they never calculate a second answer.
 
 The corpus counts describe the checked-out source on 2026-08-16. They are a
 regression baseline, not fixed framework quotas.
+
+The post-release 3.13.104 worklist is recorded in
+`metrics-evaluation-2026-08-16.md`: 1,389 findings across 387 files after
+dev-admin exclusions. Of these, 165 are errors, 1,147 are warnings, and 77 are
+informational `no_test_reference` signals. The counts are evidence from Tina4
+client 3.8.76, not fixed quotas or coverage claims.
 
 ## Public surface contract
 
@@ -191,7 +197,7 @@ These breaks are intentional before 3.14.0. No temporary JSON alias is required.
 
 ## Implementation backlog
 
-No engine or adapter work remains for the approved audit decisions. Release
+No engine or adapter work remains for the approved audit decisions. Released
 integration must preserve the green focused handoffs and contract checker.
 Delphi support remains a separate language-provider task until a grammar
 passes representative corpus fixtures.

--- a/plan/v3/metrics-evaluation-2026-08-16.md
+++ b/plan/v3/metrics-evaluation-2026-08-16.md
@@ -2,7 +2,9 @@
 
 **Outcome:** The released engine exposed four correctness gaps. ADR-0055 resolves
 them in the rebuilt engine: production-source controls, an honest test-reference
-signal, equal callable scopes, and comment-insensitive Type-2 matching.
+signal, equal callable scopes, and comment-insensitive Type-2 matching. The
+3.13.104 post-release scan now records the framework worklist produced by the
+corrected 3.8.76 client.
 
 ## Scope
 
@@ -13,6 +15,8 @@ signal, equal callable scopes, and comment-insensitive Type-2 matching.
 - [x] Rank error/warn offenders separately from informational missing-test signals.
 - [x] Reproduce false positives, blind spots, and cross-language scope differences.
 - [x] Produce a remediation order without changing framework code.
+- [x] Rebaseline all four released 3.13.104 backends on the Linux lab with Tina4 client 3.8.76.
+- [x] Record finding counts, affected files, scan roots, exclusions, and leading offenders.
 
 ## Parity dashboard
 
@@ -107,8 +111,81 @@ corrected engine. The Python corpus moves from 1.71s to 2.04s. The added work
 parses conventional tests once and reuses their import index; it does not repeat
 that parse for every production file.
 
+## 3.13.104 post-release baseline
+
+The Linux lab scan ran as root on 2026-08-17 with the signed Tina4 client
+3.8.76. It measured the released 3.13.104 source copied under
+`/home/andre/release-3.13.104/`.
+
+Each scan targeted the framework source root: `tina4_python`, `Tina4`, `lib`, or
+`packages`. The client's production defaults excluded tests, specs, declaration
+files, generated bundles, minified assets, dependencies, caches, and build
+output. Explicit globs excluded Python `dev_admin`, PHP `DevAdmin.php` and its
+security middleware, Ruby `dev_admin.rb`, Node.js `devAdmin.ts`, and synced
+dev-admin browser assets. Node.js galleries stayed in the scan because they ship
+inside the production package tree.
+
+| Framework | Files measured | Functions | Avg CC | Avg MI | Error | Warn | Info | Findings | Files with findings |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Python | 105 | 2,623 | 3.77 | 26.9 | 49 | 262 | 8 | 319 | 73 |
+| PHP | 160 | 2,915 | 3.71 | 34.6 | 51 | 345 | 20 | 416 | 105 |
+| Ruby | 125 | 4,098 | 2.73 | 29.9 | 24 | 216 | 14 | 254 | 90 |
+| Node.js | 147 | 3,389 | 3.34 | 31.1 | 41 | 324 | 35 | 400 | 119 |
+| **Total** | **537** | **13,025** | - | - | **165** | **1,147** | **77** | **1,389** | **387** |
+
+The worklist contains 1,312 warning or error findings. A finding is not a file:
+one file can raise several signals. The 77 informational findings are
+`no_test_reference` evidence gaps. They do not claim missing execution or
+coverage, and they do not fail a warning or error gate. Every scan completed
+with zero refused files.
+
+### Findings by rule
+
+| Rule | Python | PHP | Ruby | Node.js | Total |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Function complexity | 166 | 190 | 112 | 189 | 657 |
+| Duplication | 61 | 114 | 38 | 90 | 303 |
+| Too many functions | 45 | 49 | 68 | 51 | 213 |
+| Large file | 27 | 24 | 19 | 22 | 92 |
+| Low maintainability | 12 | 19 | 3 | 13 | 47 |
+| No test reference | 8 | 20 | 14 | 35 | 77 |
+
+Complexity supplies 657 of the 1,389 findings. Duplication comes next with 303.
+These two rules own 69% of the worklist, so the remediation pass should start
+there instead of splitting files to satisfy line counts alone.
+
+### Highest-ranked released findings
+
+| Framework | First priority | Next priority |
+| --- | --- | --- |
+| Python | `session_handlers/redis_handler.py`: 210 duplicated lines across two files | `swagger/__init__.py`: `Swagger.generate` CC 64 |
+| PHP | `Session/RedisSessionHandler.php`: 287 duplicated lines across two files | `AITools.php`: 50 duplicated lines within the file |
+| Ruby | `tina4/webserver.rb`: 79 duplicated lines within the file | `tina4/frond.rb`: 22 duplicated lines across three copies |
+| Node.js | `core/src/sessionHandlers/mongoClient.ts`: 229 duplicated lines across two files | `core/gallery/auth/src/routes/gallery/auth/get.ts`: 98 duplicated lines across two files |
+
+The ranking is a work order, not permission to delete repeated code without
+reading it. Shared protocol and adapter shapes may need duplication to stay
+clear. Each change still needs characterisation tests, a before/after metric,
+and the full framework suite.
+
+### Reproduction commands
+
+Use the matching source root and repeat the framework's dev-admin exclusions:
+
+```bash
+tina4 metrics --path tina4_python --exclude '**/dev_admin/**' --json --top 100000
+tina4 metrics --path Tina4 --exclude '**/DevAdmin.php' --exclude '**/DevAdminSecurityMiddleware.php' --json --top 100000
+tina4 metrics --path lib --exclude '**/dev_admin.rb' --json --top 100000
+tina4 metrics --path packages --exclude '**/devAdmin.ts' --json --top 100000
+```
+
+Add the synced `tina4-dev-admin.min.js` exclusion when the source root contains
+that asset. The default production filter already ignores minified files, but
+the explicit exclusion makes the audit boundary visible.
+
 ## Commits
 
 - `fffb85c` - re-audit the native metrics feature, correct stale claims, and record the measured framework evaluation.
+- Pending - record the released 3.13.104 metrics baseline and publish the current CLI contract.
 
-## Status: Evaluation complete; approved corrections verified locally and on the Linux lab as root
+## Status: Evaluation complete; corrected engine and 3.13.104 baseline verified on the Linux lab as root

--- a/plan/v3/metrics-evaluation-2026-08-16.md
+++ b/plan/v3/metrics-evaluation-2026-08-16.md
@@ -186,6 +186,6 @@ the explicit exclusion makes the audit boundary visible.
 ## Commits
 
 - `fffb85c` - re-audit the native metrics feature, correct stale claims, and record the measured framework evaluation.
-- Pending - record the released 3.13.104 metrics baseline and publish the current CLI contract.
+- `67ff8be` - record the released 3.13.104 metrics baseline and publish the current CLI contract.
 
 ## Status: Evaluation complete; corrected engine and 3.13.104 baseline verified on the Linux lab as root

--- a/tina4press.config.mjs
+++ b/tina4press.config.mjs
@@ -116,7 +116,7 @@ const BACKEND_GROUPS = [
 
 export default {
   title: "Tina4",
-  description: "One framework, four languages, ninety-seven features, zero runtime dependencies.",
+  description: "One framework, four languages, 137 features, zero runtime dependencies.",
   hostname: "https://tina4.com",
   base: "/",
   cleanUrls: true,
@@ -190,6 +190,7 @@ export default {
           text: "Understanding Tina4",
           stems: ["what-is-tina4", "architecture", "choosing-your-language", "environment-variables"],
         },
+        { text: "Developer tools", stems: ["cli"] },
       ],
     },
     search: true,


### PR DESCRIPTION
## Summary
- publish the lab metrics baseline across all four frameworks
- document the current native metrics command and CI contract
- correct the landing page and 3.13.104 release date
- remove stale CLI commands and expose the CLI guide in navigation

## Verification
- `python3 scripts/audit-truth.py --strict` against all four 3.13.104 tags
- Tina4Press build: 284 pages