### PR TITLE
docs: complete SSO, GIS, and IoT guides

### DIFF
--- a/docs/nodejs/40-sso.md
+++ b/docs/nodejs/40-sso.md
@@ -1,6 +1,11 @@
 # OpenID Connect SSO
 
-Tina4 uses one provider-neutral OpenID Connect flow. Configure an issuer; the framework discovers its endpoints, runs Authorization Code with PKCE, verifies the result through introspection, and hands the normalized identity to the existing Session and secured-route gate.
+Tina4 completes one provider-neutral OpenID Connect flow. Configure an issuer
+and Tina4 discovers the provider, runs Authorization Code with PKCE, regenerates
+the Session, and sends the normalized identity through the existing secured
+route gate. The browser keeps the normal Tina4 Session cookie.
+
+## Configure SSO
 
 ```ini
 TINA4_SSO_ISSUER=https://identity.example.com/realms/my-app
@@ -9,21 +14,59 @@ TINA4_SSO_CLIENT_SECRET=replace-me
 TINA4_SSO_REDIRECT_URI=https://app.example.com/auth/callback
 TINA4_SSO_SCOPES=["openid", "profile", "email"]
 TINA4_SSO_VERIFY=introspection
+TINA4_SSO_POST_LOGOUT_REDIRECT_URI=https://app.example.com/
 ```
 
-When configured, `tina4 serve` mounts `GET /auth/login`, `GET /auth/callback`, and `POST /auth/logout`. Route collisions fail startup. Existing secured routes receive the identity through `request.user`; there is no SSO-only gate.
+SSO stays off until the issuer, client id, and redirect URI exist. Production
+issuer and callback URLs require HTTPS; loopback HTTP remains available for development.
+When configured, Tina4 mounts `GET /auth/login`, `GET /auth/callback`, and
+`POST /auth/logout`. A route collision stops startup with an error.
+
+## Use the identity
+
+Secured routes use the same gate as local Tina4 authentication. The normalized
+identity is available as `request.user`. Provider tokens never enter it, logs,
+error pages, Swagger, or `session.all()`.
 
 ```typescript
 import { Sso } from "tina4-nodejs";
 
-const sso = await Sso.fromIssuer();
-const identity = sso.identity(request.session);
+if (Sso.configured()) {
+  const sso = await Sso.fromIssuer();
+  const metadata = await sso.discover();
+  const identity = sso.identity(request);
+}
 ```
 
-Provider tokens remain in reserved Session data and never appear in `session.all()`.
+| Method | Result |
+| --- | --- |
+| `Sso.configured()` | Reports whether required environment values exist. |
+| `Sso.fromIssuer()` | Creates the client and discovers the issuer. |
+| `discover(force = false)` | Returns validated metadata. Force refreshes it. |
+| `login(request, returnTo = "/")` | Stores one-use state and returns the authorization URL. |
+| `callback(request, query)` | Validates the callback and regenerates Session. |
+| `identity(request)` | Returns the normalized identity or `null`. |
+| `refresh(request)` | Replaces credentials and identity atomically. |
+| `logout(request, returnTo = "/")` | Destroys Session and returns the safe logout target. |
 
-## Provider recipes
+The return path must be local and absolute. Tina4 rejects schemes, hosts,
+protocol-relative URLs, backslashes, and control characters.
 
-The runtime does not name providers. Keycloak uses its realm issuer, such as `https://sso.example.com/realms/my-realm`. Microsoft Entra ID uses its tenant v2 issuer, such as `https://login.microsoftonline.com/your-tenant-id/v2.0`. Register the Tina4 callback URI and use `TINA4_SSO_CLAIM_MAP` only when roles or groups use different claim names.
+## Claims and provider recipes
 
-Production issuer and callback URLs require HTTPS; HTTP is loopback-only. Introspection is the supported 3.13.104 verification mode and requires a client secret. `jwks` fails during configuration until an application cryptography capability is available.
+```ini
+TINA4_SSO_CLAIM_MAP={"username":"preferred_username","roles":"realm_access.roles","groups":"groups"}
+```
+
+The runtime does not name providers. Keycloak uses a realm issuer such as
+`https://sso.example.com/realms/my-realm`. Microsoft Entra ID uses its
+tenant-specific v2 issuer. Register the exact callback URI and map claims only
+when roles or groups use different names.
+
+Version 3.13.104 supports introspection without another npm package and needs a
+client secret. Selecting `jwks` fails during configuration until the application
+installs a supported cryptography capability. State, nonce, code, and verifier
+are one-use. Logout always destroys the local Session first.
+
+When configured, Swagger publishes the issuer discovery URL as an
+`openIdConnect` scheme.

--- a/docs/nodejs/41-gis.md
+++ b/docs/nodejs/41-gis.md
@@ -1,24 +1,55 @@
 # GIS and PostGIS
 
-Tina4 stores geographic points in PostGIS, queries distance in metres, and returns GeoJSON. Coordinates are always `[longitude, latitude]`.
+Tina4 stores geographic points in PostGIS, measures distance in metres, and
+returns map-ready GeoJSON. Coordinates always use longitude first. GPS may
+supply coordinates, but GIS is the feature.
+
+## Define a point field
+
+Enable PostGIS with `CREATE EXTENSION IF NOT EXISTS postgis;`.
 
 ```typescript
-import { Point } from "tina4-nodejs/orm";
+import { BaseModel, Point } from "tina4-nodejs/orm";
+
+class ChargePoint extends BaseModel {
+  static tableName = "charge_point";
+  static fields = {
+    location: { type: "point", srid: 4326, spatialIndex: true },
+  };
+}
 
 site.location = new Point(18.4241, -33.9249);
 await site.save();
+```
 
+Tina4 creates `geography(Point,4326)` and an idempotent GiST index. Unsupported
+database engines and PostgreSQL without PostGIS fail clearly. `Point.parse()`
+accepts a Point, number pair, WKT or EWKT, GeoJSON Point or Feature, and WKB or
+EWKB. It rejects invalid ranges, non-finite numbers, non-point geometry, and
+conflicting SRIDs before SQL runs.
+
+## Query and return GeoJSON
+
+```typescript
 const nearby = await ChargePoint.query()
   .withinDistance("location", [18.42, -33.92], 5_000)
-  .selectDistance("location", [18.42, -33.92])
+  .selectDistance("location", [18.42, -33.92], "metres")
   .orderByDistance("location", [18.42, -33.92])
   .get();
 
 const feature = site.toFeature();
+const collection = BaseModel.featureCollection(nearby);
 ```
 
-Declare the model field as `location: { type: "point", srid: 4326,
-spatialIndex: true }`. Tina4 maps it to `geography(Point,4326)` and creates a
-GiST index. Unsupported database engines fail clearly. `Point.parse()` accepts
-coordinate pairs, WKT/EWKT, GeoJSON, or WKB/EWKB and never guesses coordinate
-order.
+The query builder also provides `intersects()` for bound WKT, EWKT, or GeoJSON
+geometry and `bbox()` for a validated bounding box. Spatial values use bound
+parameters. Column and alias names are validated as identifiers.
+
+`toFeature()` moves the chosen Point into `geometry` and keeps other selected
+fields in `properties`. A null point creates `"geometry": null`.
+`featureCollection()` preserves query order. Supply a geometry field for models
+with several Point fields and an include list to limit properties.
+
+Version 3.13.104 persists Point fields only. It does not persist lines,
+polygons, rasters, tiles, geocoding results, or routes. `intersects()` may accept
+a polygon as query geometry. PostGIS is the only storage provider.

--- a/docs/nodejs/42-iot-mqtt.md
+++ b/docs/nodejs/42-iot-mqtt.md
@@ -1,0 +1,55 @@
+# IoT and MQTT
+
+Tina4 includes a zero-dependency MQTT 3.1.1 client for telemetry, device state,
+asset tracking, and EV charging. It connects to an external broker such as
+Mosquitto, EMQX, HiveMQ, or AWS IoT. Tina4 is not a broker.
+
+## Configure, connect, and publish
+
+```ini
+TINA4_MQTT_URL=mqtt://127.0.0.1:1883
+TINA4_MQTT_CLIENT_ID=warehouse-api
+TINA4_MQTT_KEEPALIVE=60
+TINA4_MQTT_TLS_VERIFY=true
+TINA4_MQTT_CA_FILE=/run/secrets/mqtt-ca.pem
+```
+
+Use `mqtt://` or `tcp://` for plain TCP and `mqtts://` for TLS. Put credentials
+in URL user information or constructor options. There are no username or
+password environment variables.
+
+```typescript
+import { Mqtt } from "tina4-nodejs";
+
+const mqtt = new Mqtt();
+await mqtt.connect();
+const packetId = await mqtt.publish(
+  "fleet/meter-42/telemetry",
+  JSON.stringify({ kwh: 12.5 }),
+  1,
+);
+await mqtt.disconnect();
+```
+
+Node.js connects explicitly. QoS 0 waits for no acknowledgement. QoS 1 returns
+the packet id after PUBACK. Tina4 refuses QoS 2.
+
+```typescript
+const mqtt = new Mqtt({ cleanSession: false });
+await mqtt.connect();
+
+for await (const message of mqtt.consume("fleet/+/telemetry", 1)) {
+  process(message.topic, message.text());
+}
+```
+
+`consume()` acknowledges after successful loop handling. Use
+`receive(undefined, false)` followed by `message.acknowledge()` for manual
+control. Messages expose topic, byte payload, QoS, packet id, retained and
+duplicate flags, acknowledgement, `text()`, and `toObject()`.
+
+Retained publishes store current state; an empty retained payload clears it.
+Configure `willTopic`, `willPayload`, `willQos`, and `willRetain` for an unclean
+disconnect. `disconnect()` suppresses the will; `kill()` lets the broker publish
+it. TLS verification defaults to true. `tls()`, `cipher()`, and `tlsVersion()`
+report the connection. One client has one socket reader.

--- a/docs/nodejs/index.md
+++ b/docs/nodejs/index.md
@@ -929,6 +929,21 @@ import { AVAILABLE_LANGUAGES } from "tina4-nodejs";
 // ["en", "fr", "af"]
 ```
 
+### OpenID Connect SSO <a href="#sso" id="sso"></a>
+
+Configure any standard OIDC issuer, then use the normal secured-route gate and
+Tina4 Session. See [OpenID Connect SSO](./40-sso.md) for the complete client API.
+
+### GIS and PostGIS <a href="#gis" id="gis"></a>
+
+Declare a Point field, query metres, and return GeoJSON. Coordinates are
+longitude then latitude. See [GIS and PostGIS](./41-gis.md).
+
+### IoT and MQTT <a href="#iot-mqtt" id="iot-mqtt"></a>
+
+Use the MQTT 3.1.1 client for QoS 0/1 telemetry, retained state, Last Will, and
+verified TLS. See [IoT and MQTT](./42-iot-mqtt.md).
+
 ***
 
 ## 📕 Download the book

--- a/docs/php/41-sso.md
+++ b/docs/php/41-sso.md
@@ -1,6 +1,9 @@
 # OpenID Connect SSO
 
-Tina4 uses one provider-neutral OpenID Connect flow. Configure an issuer; the framework discovers its endpoints, runs Authorization Code with PKCE, verifies the result through introspection, and stores the normalized identity in the existing Tina4 Session.
+Tina4 completes one provider-neutral OpenID Connect flow. Configure an issuer
+and Tina4 discovers the provider, runs Authorization Code with PKCE, regenerates
+the Session, and sends the normalized identity through the existing secured
+route gate. The browser keeps the normal Tina4 Session cookie.
 
 ## Configure SSO
 
@@ -14,25 +17,68 @@ TINA4_SSO_VERIFY=introspection
 TINA4_SSO_POST_LOGOUT_REDIRECT_URI=https://app.example.com/
 ```
 
-SSO is off unless the required values are present. When configured, `tina4 serve` mounts `GET /auth/login`, `GET /auth/callback`, and `POST /auth/logout`. A collision with an application route fails startup.
+SSO stays off until the issuer, client id, and redirect URI exist. A
+confidential client also needs its secret. Production issuer and callback URLs
+require HTTPS. Loopback HTTP remains available for local development.
 
-Use the existing secured-route mechanism. The normalized identity is available as `$request->user`; provider tokens remain in reserved Session data and never appear in `Session::all()`.
+When configured, Tina4 mounts:
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/auth/login` | Start login and create one-use state, nonce, and PKCE values. |
+| `GET` | `/auth/callback` | Validate state, exchange the code, and create the identity. |
+| `POST` | `/auth/logout` | Destroy the local Session and request provider logout. |
+
+A route collision stops startup with an error.
+
+## Use the identity
+
+Secured routes use the same authentication gate as local Tina4 authentication.
+The normalized identity is available as `$request->user`. Provider tokens never
+enter that value, logs, error pages, Swagger, or `Session::all()`.
 
 ```php
 use Tina4\Sso;
 
-$sso = Sso::fromIssuer();
-$identity = $sso->identity($request->session);
+if (Sso::configured()) {
+    $sso = Sso::fromIssuer();
+    $metadata = $sso->discover();
+    $identity = $sso->identity($request);
+}
 ```
 
-## Provider recipes
+| Method | Result |
+| --- | --- |
+| `Sso::configured()` | Reports whether required environment values exist. |
+| `Sso::fromIssuer()` | Creates the client and discovers the issuer. |
+| `discover($force = false)` | Returns validated metadata. Force refreshes it. |
+| `login($request, $returnTo = '/')` | Stores one-use state and returns the authorization URL. |
+| `callback($request, $query = null)` | Validates the callback and regenerates Session. |
+| `identity($request)` | Returns the normalized identity or `null`. |
+| `refresh($request)` | Replaces credentials and identity atomically. |
+| `logout($request, $returnTo = '/')` | Destroys Session and returns the safe logout target. |
 
-The runtime does not name providers. For Keycloak, set the realm issuer:
+`returnTo` accepts a local absolute path. Tina4 rejects schemes, hosts,
+protocol-relative URLs, backslashes, and control characters.
+
+## Map claims and providers
 
 ```ini
-TINA4_SSO_ISSUER=https://sso.example.com/realms/my-realm
+TINA4_SSO_CLAIM_MAP={"username":"preferred_username","roles":"realm_access.roles","groups":"groups"}
 ```
 
-Enable authorization-code flow and register `https://app.example.com/auth/callback`. For Microsoft Entra ID, use `https://login.microsoftonline.com/your-tenant-id/v2.0` as the issuer. Use `TINA4_SSO_CLAIM_MAP` when a provider exposes roles or groups under different claim names.
+The runtime does not name providers. For Keycloak, use a realm issuer such as
+`https://sso.example.com/realms/my-realm`. For Microsoft Entra ID, use the
+tenant-specific v2 issuer. Register the exact Tina4 callback URI in either
+provider. Use a claim map only when roles or groups use different claim names.
 
-Production issuer and callback URLs must use HTTPS; HTTP is loopback-only. Introspection is the supported verification mode in 3.13.104 and requires a client secret. `jwks` fails at configuration until an application cryptography capability is available.
+Version 3.13.104 supports introspection without another PHP package and needs a
+client secret. Selecting `jwks` fails during configuration until the application
+installs a supported cryptography capability. State, nonce, code, and verifier
+are one-use. Logout always destroys the local Session first.
+
+## Swagger
+
+When configured, Swagger publishes the issuer discovery URL as an
+`openIdConnect` scheme. Secured routes accept the normal Tina4 Session cookie or
+the configured bearer scheme.

--- a/docs/php/42-gis.md
+++ b/docs/php/42-gis.md
@@ -1,23 +1,71 @@
 # GIS and PostGIS
 
-Tina4 stores geographic points in PostGIS, queries distance in metres, and returns map-ready GeoJSON. Coordinates are always `[longitude, latitude]`.
+Tina4 stores geographic points in PostGIS, measures distance in metres, and
+returns map-ready GeoJSON. Public coordinates always use longitude first:
+`[longitude, latitude]`. GPS may supply coordinates, but GIS is the feature.
+
+## Define a point field
+
+Enable PostGIS first with `CREATE EXTENSION IF NOT EXISTS postgis;`.
 
 ```php
+use Tina4\ORM;
 use Tina4\Point;
+
+class ChargePoint extends ORM
+{
+    public ?Point $location = null;
+    public array $pointFields = [
+        'location' => ['srid' => 4326, 'spatialIndex' => true],
+    ];
+}
+
 $site->location = new Point(18.4241, -33.9249);
 $site->save();
-
-$nearby = ChargePoint::query()
-    ->withinDistance('location', [18.42, -33.92], 5000)
-    ->selectDistance('location', [18.42, -33.92])
-    ->orderByDistance('location', [18.42, -33.92])
-    ->get();
-
-$feature = $site->toFeature();
 ```
 
-Declare the model field with `public ?Point $location = null` and add
-`'location' => ['srid' => 4326, 'spatialIndex' => true]` to the model's
-`$pointFields` map. Tina4 then creates `geography(Point,4326)` and a GiST index.
-Unsupported database engines fail clearly. `Point::parse()` accepts coordinate
-pairs, WKT/EWKT, GeoJSON, or WKB/EWKB; `geoJson()` returns the standard geometry.
+Tina4 creates `geography(Point,4326)` and an idempotent GiST index. Unsupported
+database engines and PostgreSQL without PostGIS fail clearly.
+
+`Point::parse()` accepts a Point, a two-number pair, WKT or EWKT, GeoJSON Point
+or Feature, and WKB or EWKB. It rejects invalid ranges, non-finite numbers,
+non-point geometry, and conflicting SRIDs before SQL runs. SQL `NULL` remains
+`null`; `(0, 0)` remains a real point.
+
+## Query spatial data
+
+```php
+$nearby = ChargePoint::query()
+    ->withinDistance('location', [18.42, -33.92], 5000)
+    ->selectDistance('location', [18.42, -33.92], 'metres')
+    ->orderByDistance('location', [18.42, -33.92])
+    ->get();
+```
+
+| Method | Meaning |
+| --- | --- |
+| `withinDistance($column, $point, $metres)` | Keep rows inside a non-negative radius. |
+| `selectDistance($column, $point, $alias)` | Add distance in metres to each row. |
+| `orderByDistance($column, $point, $descending)` | Sort with a stable primary-key tie-break. |
+| `intersects($column, $geometry)` | Match bound WKT, EWKT, or GeoJSON geometry. |
+| `bbox($column, $minLon, $minLat, $maxLon, $maxLat)` | Match a validated bounding box. |
+
+Spatial values use bound parameters. Column and alias names are validated as
+identifiers.
+
+## Return GeoJSON
+
+```php
+$feature = $site->toFeature();
+$collection = ORM::featureCollection($nearby);
+return $response->json($collection);
+```
+
+`toFeature()` moves the selected Point into `geometry` and keeps other selected
+fields in `properties`. A null point creates `"geometry": null`.
+`featureCollection()` preserves query order. Supply a geometry field when a
+model has more than one Point field and an include list to limit properties.
+
+Version 3.13.104 persists Point fields only. It does not persist lines,
+polygons, rasters, tiles, geocoding results, or routes. `intersects()` may still
+accept a polygon as bound query geometry. PostGIS is the only storage provider.

--- a/docs/php/43-iot-mqtt.md
+++ b/docs/php/43-iot-mqtt.md
@@ -1,0 +1,59 @@
+# IoT and MQTT
+
+Tina4 includes a zero-dependency MQTT 3.1.1 client for telemetry, device state,
+asset tracking, and EV charging. It connects to an external broker such as
+Mosquitto, EMQX, HiveMQ, or AWS IoT. Tina4 is not a broker.
+
+## Configure and publish
+
+```ini
+TINA4_MQTT_URL=mqtt://127.0.0.1:1883
+TINA4_MQTT_CLIENT_ID=warehouse-api
+TINA4_MQTT_KEEPALIVE=60
+TINA4_MQTT_TLS_VERIFY=true
+TINA4_MQTT_CA_FILE=/run/secrets/mqtt-ca.pem
+```
+
+Use `mqtt://` or `tcp://` for plain TCP and `mqtts://` for TLS. Put credentials
+in URL user information or explicit constructor arguments. Broker credentials
+do not have dedicated environment variables.
+
+```php
+use Tina4\Mqtt;
+
+$mqtt = new Mqtt();
+$packetId = $mqtt->publish(
+    'fleet/meter-42/telemetry',
+    '{"kwh":12.5}',
+    qos: 1
+);
+$mqtt->disconnect();
+```
+
+Construction connects by default. QoS 0 waits for no acknowledgement. QoS 1
+returns the packet id after PUBACK. Tina4 refuses QoS 2 instead of silently
+downgrading it.
+
+## Consume safely
+
+```php
+$mqtt = new Mqtt(cleanSession: false);
+
+foreach ($mqtt->consume('fleet/+/telemetry', qos: 1) as $message) {
+    process($message->topic, $message->text());
+}
+```
+
+`consume()` acknowledges after successful loop handling. Use
+`receive(ack: false)` followed by `$message->acknowledge()` for manual control.
+Messages expose topic, byte payload, QoS, packet id, retained and duplicate
+flags, `acknowledge()`, `text()`, and `toArray()`.
+
+Retained publishes store current device state; an empty retained payload clears
+it. Configure `willTopic`, `willPayload`, `willQos`, and `willRetain` to report
+an unclean disconnect. `disconnect()` suppresses the will; `kill()` lets the
+broker publish it.
+
+Each client builds its own TLS trust store. Verification defaults to true.
+`tls()`, `cipher()`, and `tlsVersion()` report the negotiated connection. One
+client has one socket reader, so independent consumers need separate clients.

--- a/docs/php/index.md
+++ b/docs/php/index.md
@@ -732,6 +732,21 @@ $fake = new FakeData(seed: 42);
 
 Use `FakeData` inside migrations, seeders, or test fixtures.
 
+### OpenID Connect SSO <a href="#sso" id="sso"></a>
+
+Configure any standard OIDC issuer, then use the normal secured-route gate and
+Tina4 Session. See [OpenID Connect SSO](./41-sso.md) for the complete client API.
+
+### GIS and PostGIS <a href="#gis" id="gis"></a>
+
+Declare a Point field, query metres, and return GeoJSON. Coordinates are
+longitude then latitude. See [GIS and PostGIS](./42-gis.md).
+
+### IoT and MQTT <a href="#iot-mqtt" id="iot-mqtt"></a>
+
+Use the MQTT 3.1.1 client for QoS 0/1 telemetry, retained state, Last Will, and
+verified TLS. See [IoT and MQTT](./43-iot-mqtt.md).
+
 ***
 
 ## 📕 Download the book

--- a/docs/python/41-sso.md
+++ b/docs/python/41-sso.md
@@ -1,6 +1,12 @@
 # OpenID Connect SSO
 
-Tina4 uses one provider-neutral OpenID Connect flow. Configure an issuer; the framework discovers its endpoints, runs Authorization Code with PKCE, verifies the result through introspection, and stores the normalized identity in the existing Tina4 Session.
+Tina4 completes one provider-neutral OpenID Connect flow. You configure an
+issuer. Tina4 discovers the provider, runs Authorization Code with PKCE,
+verifies the result, regenerates the Session, and hands the normalized identity
+to the existing secured-route gate.
+
+No provider SDK. No second authentication system. The browser keeps the normal
+Tina4 Session cookie.
 
 ## Configure SSO
 
@@ -14,47 +20,130 @@ TINA4_SSO_VERIFY=introspection
 TINA4_SSO_POST_LOGOUT_REDIRECT_URI=https://app.example.com/
 ```
 
-SSO is off unless the required values are present. When configured, `tina4 serve` mounts `GET /auth/login`, `GET /auth/callback`, and `POST /auth/logout`. Defining one of those routes yourself is a startup error, so an application never silently replaces part of the login flow.
+SSO stays off until the issuer, client id, and redirect URI exist. A
+confidential client also needs its secret. Production issuer and callback URLs
+require HTTPS. Loopback HTTP remains available for local development.
 
-An authenticated browser keeps only the normal Tina4 Session cookie. Provider tokens stay in reserved Session data and never appear in `session.all()` or `request.user`.
+When configured, Tina4 mounts these routes:
 
-## Use the signed-in identity
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/auth/login` | Start login and create one-use state, nonce, and PKCE values. |
+| `GET` | `/auth/callback` | Validate state, exchange the code, and create the Session identity. |
+| `POST` | `/auth/logout` | Destroy the local Session, then request provider logout when supported. |
 
-Use the normal secured-route mechanism. There is no SSO-only decorator.
+An application route that collides with one of these paths stops startup with
+an error. Tina4 never replaces part of the login flow in silence.
+
+## Protect a route
+
+SSO uses the same `@secured()` gate as local Tina4 authentication.
 
 ```python
-from tina4_python import get, Sso
+from tina4_python import get, secured
 
 @get("/account")
+@secured()
 async def account(request, response):
     return response.json(request.user)
-
-sso = Sso.from_issuer()
-identity = sso.identity(request.session)
 ```
 
-`request.user` contains `issuer`, `subject`, `username`, `email`, `name`, and sorted `roles` and `groups`. Provider tokens are deliberately excluded.
+`request.user` contains:
+
+```json
+{
+  "issuer": "https://identity.example.com/realms/my-app",
+  "subject": "provider-stable-subject",
+  "username": "andre",
+  "email": "andre@example.com",
+  "name": "Andre",
+  "roles": ["admin", "developer"],
+  "groups": ["/engineering"]
+}
+```
+
+Issuer and subject are required. Roles and groups are sorted, de-duplicated
+lists. Provider tokens never enter `request.user`, logs, error pages, Swagger,
+or `session.all()`.
+
+## Use the SSO client
+
+Automatic routes cover the normal browser flow. The public client remains
+available when an application needs to start or inspect the flow itself.
+
+```python
+from tina4_python import Sso
+
+if Sso.configured():
+    sso = Sso.from_issuer()
+    metadata = sso.discover()
+    identity = sso.identity(request)
+```
+
+| Method | Result |
+| --- | --- |
+| `Sso.configured()` | Reports whether the required environment values exist. |
+| `Sso.from_issuer()` | Creates the client and discovers the configured issuer. |
+| `discover(force=False)` | Returns validated provider metadata. `force=True` refreshes it. |
+| `login(request, return_to="/")` | Stores one-use login state and returns the authorization URL. |
+| `callback(request, query=None)` | Validates the callback, regenerates Session, and returns identity plus the local return path. |
+| `identity(request)` | Returns the normalized identity or `None`. |
+| `refresh(request)` | Replaces provider credentials and identity atomically. |
+| `logout(request, return_to="/")` | Destroys local Session first and returns the safe logout target. |
+
+`return_to` accepts a local absolute path. Tina4 rejects schemes, hosts,
+protocol-relative URLs, backslashes, and control characters.
+
+## Map provider claims
+
+Use `TINA4_SSO_CLAIM_MAP` when a provider stores a normalized field under
+another claim path:
+
+```ini
+TINA4_SSO_CLAIM_MAP={"username":"preferred_username","roles":"realm_access.roles","groups":"groups"}
+```
+
+The value is a native `.env` object, not a comma-separated string.
 
 ## Provider recipes
 
-The runtime does not name providers. A recipe only supplies standard configuration.
+The runtime does not name providers. Recipes only supply standard OIDC values.
 
-For Keycloak, use the realm issuer:
+### Keycloak
 
 ```ini
 TINA4_SSO_ISSUER=https://sso.example.com/realms/my-realm
+TINA4_SSO_REDIRECT_URI=https://app.example.com/auth/callback
 ```
 
-Register `https://app.example.com/auth/callback` as a valid redirect URI and configure the client for authorization-code flow. Map realm roles, client roles, or groups into claims when your application needs them.
+Enable Authorization Code flow, register the exact callback URI, and map realm
+roles, client roles, or groups into claims when the application needs them.
 
-For Microsoft Entra ID, use the tenant-specific v2 issuer:
+### Microsoft Entra ID
 
 ```ini
 TINA4_SSO_ISSUER=https://login.microsoftonline.com/your-tenant-id/v2.0
+TINA4_SSO_REDIRECT_URI=https://app.example.com/auth/callback
 ```
 
-Register the same callback URI and use `TINA4_SSO_CLAIM_MAP` when your tenant exposes roles or groups under different claim names.
+Use the tenant-specific v2 issuer. Add a claim map only when the tenant exposes
+roles or groups under different names.
 
-## Security boundary
+## Verification and failure rules
 
-Production issuer and callback URLs must use HTTPS; plain HTTP is accepted only on loopback for local testing. External return URLs are rejected. Introspection is the supported verification mode in 3.13.104 and requires a client secret. Selecting `jwks` fails during configuration until an application cryptography capability is available.
+Version 3.13.104 supports introspection without an extra Python package. It
+requires a confidential client secret. Selecting `jwks` fails during
+configuration until the application installs a supported cryptography
+capability.
+
+State, nonce, authorization code, and PKCE verifier are one-use. A mismatch or
+replay creates no identity. A failed refresh removes SSO identity rather than
+continuing with expired credentials. Logout always destroys the local Session
+before it contacts the provider.
+
+## Swagger
+
+When SSO is configured, Swagger publishes the issuer discovery URL as an
+`openIdConnect` scheme. Secured routes accept the normal Tina4 Session cookie or
+the configured bearer scheme. Swagger never presents a provider access token as
+a Tina4 Session.

--- a/docs/python/42-gis.md
+++ b/docs/python/42-gis.md
@@ -1,11 +1,28 @@
 # GIS and PostGIS
 
-Tina4's GIS support stores geographic points in PostGIS, queries distance in metres, and serializes map-ready GeoJSON. Coordinates are always `(longitude, latitude)`.
+Tina4 stores geographic points in PostGIS, measures distance in metres, and
+returns map-ready GeoJSON. Public coordinates always use longitude first:
+`(longitude, latitude)`.
+
+GIS describes the spatial model and queries. GPS may supply coordinates, but it
+does not define this feature.
+
+## Prepare PostGIS
+
+The first GIS provider is PostgreSQL with PostGIS:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS postgis;
+```
+
+Point fields fail with a clear error on SQLite, MySQL, SQL Server, Firebird, or
+PostgreSQL without PostGIS. Tina4 does not replace a spatial query with an
+approximation over two numeric columns.
 
 ## Define a point field
 
 ```python
-from tina4_python.orm import ORM, IntegerField, StringField, PointField, Point, feature_collection
+from tina4_python.orm import ORM, IntegerField, StringField, PointField, Point
 
 class ChargePoint(ORM):
     id = IntegerField(primary_key=True, auto_increment=True)
@@ -19,7 +36,31 @@ site = ChargePoint({
 site.save()
 ```
 
-`PointField()` creates a `geography(Point,4326)` column and a GiST index. Tina4 fails clearly on an unsupported database instead of pretending a text column is spatial.
+`PointField()` creates `geography(Point,4326)` and an idempotent GiST index.
+Set `spatial_index=False` only when another migration owns the index.
+
+## Point values
+
+`Point.parse()` accepts a `Point`, a two-number pair, WKT or EWKT, GeoJSON Point
+or Feature, and WKB or EWKB. It rejects booleans, NaN, infinity, invalid ranges,
+non-point geometry, and conflicting SRIDs before SQL runs.
+
+```python
+Point.parse([18.4241, -33.9249])
+Point.parse("POINT(18.4241 -33.9249)")
+Point.parse("SRID=4326;POINT(18.4241 -33.9249)")
+Point.parse({"type": "Point", "coordinates": [18.4241, -33.9249]})
+```
+
+| Property | Value |
+| --- | --- |
+| `.lon`, `.lat`, `.srid` | Validated point coordinates and reference id. |
+| `.wkt` | `POINT(lon lat)` |
+| `.ewkt` | `SRID=4326;POINT(lon lat)` |
+| `.geojson` | RFC 7946 Point geometry. |
+| `.to_tuple()` | `(longitude, latitude)` |
+
+SQL `NULL` remains `None`. `(0, 0)` remains a real point.
 
 ## Query by distance
 
@@ -27,19 +68,43 @@ site.save()
 nearby = (
     ChargePoint.query()
     .within_distance("location", (18.42, -33.92), 5_000)
-    .select_distance("location", (18.42, -33.92))
+    .select_distance("location", (18.42, -33.92), alias="metres")
     .order_by_distance("location", (18.42, -33.92))
     .get()
 )
 ```
 
-Radius and returned distance are metres. Spatial values remain parameters; column and alias names are validated identifiers.
+| Query method | Meaning |
+| --- | --- |
+| `within_distance(column, point, metres)` | Keep rows within the non-negative spheroid radius. |
+| `select_distance(column, point, alias="metres")` | Add the distance in metres to each row. |
+| `order_by_distance(column, point, descending=False)` | Sort by distance with a stable primary-key tie-break. |
+| `intersects(column, geometry)` | Match a bound WKT, EWKT, or GeoJSON query geometry. |
+| `bbox(column, min_lon, min_lat, max_lon, max_lat)` | Match a validated bounding box. |
+
+Spatial values use bound parameters. Tina4 validates column and alias names as
+identifiers. A bounding box rejects inverted or out-of-range coordinates.
 
 ## Return GeoJSON
 
 ```python
+from tina4_python.orm import feature_collection
+
 feature = site.to_feature()
-collection = feature_collection([site])
+collection = feature_collection(nearby)
+return response.json(collection)
 ```
 
-A `Point` also exposes `.wkt`, `.ewkt`, `.geojson`, `.lon`, `.lat`, and `.srid`. `Point.parse()` accepts a coordinate pair, WKT/EWKT, GeoJSON, or WKB/EWKB without guessing coordinate order.
+`to_feature()` moves the chosen Point field into `geometry` and keeps the other
+selected fields in `properties`. A null point produces `"geometry": null`, not
+coordinates at Null Island. `feature_collection()` preserves query order.
+
+Pass `geometry_field` when a model has more than one Point field. Pass `include`
+to select the properties that leave the application.
+
+## Limits in 3.13.104
+
+Tina4 persists Point fields only. It does not persist lines, polygons, rasters,
+tiles, geocoding results, or routes. `intersects()` may still accept a polygon as
+bound query geometry. PostGIS is the only supported storage provider in this
+release.

--- a/docs/python/43-iot-mqtt.md
+++ b/docs/python/43-iot-mqtt.md
@@ -1,0 +1,111 @@
+# IoT and MQTT
+
+Tina4 includes a zero-dependency MQTT 3.1.1 client for telemetry, device state,
+asset tracking, and EV charging applications. It connects to an external broker
+such as Mosquitto, EMQX, HiveMQ, or AWS IoT. Tina4 is not an MQTT broker.
+
+## Configure the broker
+
+```ini
+TINA4_MQTT_URL=mqtt://127.0.0.1:1883
+TINA4_MQTT_CLIENT_ID=warehouse-api
+TINA4_MQTT_KEEPALIVE=60
+TINA4_MQTT_TLS_VERIFY=true
+TINA4_MQTT_CA_FILE=/run/secrets/mqtt-ca.pem
+```
+
+Use `mqtt://` or `tcp://` for plain TCP and `mqtts://` for TLS. Credentials
+belong in URL user information or explicit constructor arguments:
+
+```ini
+TINA4_MQTT_URL=mqtts://device-user:device-password@broker.example.com:8883
+```
+
+Explicit constructor values beat URL values and environment values. Broker
+credentials do not have dedicated environment variables.
+
+## Publish telemetry
+
+Python connects when `Mqtt()` is constructed unless `connect=False`.
+
+```python
+from tina4_python.mqtt import Mqtt
+
+mqtt = Mqtt()
+packet_id = mqtt.publish(
+    "fleet/meter-42/telemetry",
+    '{"kwh":12.5,"timestamp":"2026-08-18T08:00:00Z"}',
+    qos=1,
+)
+mqtt.disconnect()
+```
+
+QoS 0 returns `None` and waits for no acknowledgement. QoS 1 returns the packet
+id after the matching PUBACK. Tina4 refuses QoS 2 instead of downgrading it.
+Use QoS 1 with an idempotency key such as `(device_id, device_timestamp)`.
+
+## Subscribe and consume
+
+```python
+mqtt = Mqtt(clean_session=False)
+
+for message in mqtt.consume("fleet/+/telemetry", qos=1):
+    process(message.topic, message.text())
+```
+
+`consume()` acknowledges after the loop resumes from a successfully handled
+message. If processing raises, the broker can redeliver the message. Use
+`receive(ack=True)` when the application wants immediate acknowledgement, or
+`receive(ack=False)` followed by `message.acknowledge()` for manual control.
+
+`MqttMessage` exposes `topic`, byte `payload`, `qos`, `packet_id`, `retained`,
+`duplicate`, `acknowledge()`, `text()`, and `to_dict()`.
+
+## Retained state and Last Will
+
+```python
+mqtt.publish("fleet/meter-42/status", "online", qos=1, retain=True)
+```
+
+A retained publish gives new subscribers the latest device state. Publishing an
+empty retained payload clears it.
+
+Use a Last Will to report an unclean disconnect:
+
+```python
+mqtt = Mqtt(
+    will_topic="fleet/meter-42/status",
+    will_payload="offline",
+    will_qos=1,
+    will_retain=True,
+)
+```
+
+`disconnect()` sends MQTT DISCONNECT and suppresses the will. `kill()` drops the
+socket so the broker publishes it.
+
+## TLS and trust
+
+Every client builds its own TLS trust store. A CA loaded for one connection
+cannot leak into another client. Verification defaults to true. Disabling it
+logs a warning because encrypted traffic without peer verification remains open
+to a man-in-the-middle attack.
+
+After a TLS connection, `mqtt.tls()`, `mqtt.cipher()`, and
+`mqtt.tls_version()` report the negotiated channel.
+
+## Public operations
+
+| Operation | Purpose |
+| --- | --- |
+| `connect()` / `connected()` | Open the broker connection and inspect its state. |
+| `publish()` | Send QoS 0 or QoS 1 data, optionally retained. |
+| `subscribe()` | Register a topic filter and return its packet id. |
+| `receive()` | Read one message with immediate or manual acknowledgement. |
+| `consume()` | Iterate messages and acknowledge after successful handling. |
+| `acknowledge()` | Send PUBACK for a packet id. |
+| `ping()` / `start_keepalive()` | Check or maintain an idle connection. |
+| `disconnect()` / `kill()` | Close cleanly or simulate an unclean device loss. |
+
+One client has one socket reader. Do not run two receive loops on the same
+instance. Create another client when independent consumers need the same topic.

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -614,6 +614,21 @@ fake.sentence()  # "The quick brown fox..."
 fake.integer()   # 4821
 ```
 
+### OpenID Connect SSO <a href="#sso" id="sso"></a>
+
+Configure any standard OIDC issuer, then use the normal secured-route gate and
+Tina4 Session. See [OpenID Connect SSO](./41-sso.md) for the complete client API.
+
+### GIS and PostGIS <a href="#gis" id="gis"></a>
+
+Declare a `PointField`, query metres, and return GeoJSON. Coordinates are
+longitude then latitude. See [GIS and PostGIS](./42-gis.md).
+
+### IoT and MQTT <a href="#iot-mqtt" id="iot-mqtt"></a>
+
+Use the MQTT 3.1.1 client for QoS 0/1 telemetry, retained state, Last Will, and
+verified TLS. See [IoT and MQTT](./43-iot-mqtt.md).
+
 ***
 
 ## 📕 Download the book

--- a/docs/ruby/40-sso.md
+++ b/docs/ruby/40-sso.md
@@ -1,6 +1,11 @@
 # OpenID Connect SSO
 
-Tina4 uses one provider-neutral OpenID Connect flow. Configure an issuer; the framework discovers its endpoints, runs Authorization Code with PKCE, verifies the result through introspection, and hands the normalized identity to the existing Session and secured-route gate.
+Tina4 completes one provider-neutral OpenID Connect flow. Configure an issuer
+and Tina4 discovers the provider, runs Authorization Code with PKCE, regenerates
+the Session, and sends the normalized identity through the existing secured
+route gate. The browser keeps the normal Tina4 Session cookie.
+
+## Configure SSO
 
 ```ini
 TINA4_SSO_ISSUER=https://identity.example.com/realms/my-app
@@ -9,19 +14,57 @@ TINA4_SSO_CLIENT_SECRET=replace-me
 TINA4_SSO_REDIRECT_URI=https://app.example.com/auth/callback
 TINA4_SSO_SCOPES=["openid", "profile", "email"]
 TINA4_SSO_VERIFY=introspection
+TINA4_SSO_POST_LOGOUT_REDIRECT_URI=https://app.example.com/
 ```
 
-When configured, `tina4 serve` mounts `GET /auth/login`, `GET /auth/callback`, and `POST /auth/logout`. Route collisions fail startup. Existing secured routes receive the identity through `request.user`; there is no SSO-only gate.
+SSO stays off until the issuer, client id, and redirect URI exist. Production
+issuer and callback URLs require HTTPS; loopback HTTP remains available for development.
+When configured, Tina4 mounts `GET /auth/login`, `GET /auth/callback`, and
+`POST /auth/logout`. A route collision stops startup with an error.
+
+## Use the identity
+
+Secured routes use the same gate as local Tina4 authentication. The normalized
+identity is available as `request.user`. Provider tokens never enter it, logs,
+error pages, Swagger, or `session.all`.
 
 ```ruby
-sso = Tina4::Sso.from_issuer
-identity = sso.identity(request.session)
+if Tina4::Sso.configured?
+  sso = Tina4::Sso.from_issuer
+  metadata = sso.discover
+  identity = sso.identity(request)
+end
 ```
 
-Provider tokens remain in reserved Session data and never appear in `session.all`.
+| Method | Result |
+| --- | --- |
+| `Tina4::Sso.configured?` | Reports whether required environment values exist. |
+| `Tina4::Sso.from_issuer` | Creates the client and discovers the issuer. |
+| `discover(force = false)` | Returns validated metadata. Force refreshes it. |
+| `login(request, return_to = "/")` | Stores one-use state and returns the authorization URL. |
+| `callback(request, query = nil)` | Validates the callback and regenerates Session. |
+| `identity(request)` | Returns the normalized identity or `nil`. |
+| `refresh(request)` | Replaces credentials and identity atomically. |
+| `logout(request, return_to = "/")` | Destroys Session and returns the safe logout target. |
 
-## Provider recipes
+The return path must be local and absolute. Tina4 rejects schemes, hosts,
+protocol-relative URLs, backslashes, and control characters.
 
-The runtime does not name providers. Keycloak uses its realm issuer, such as `https://sso.example.com/realms/my-realm`. Microsoft Entra ID uses its tenant v2 issuer, such as `https://login.microsoftonline.com/your-tenant-id/v2.0`. In either case, register the Tina4 callback URI and use `TINA4_SSO_CLAIM_MAP` only when roles or groups use different claim names.
+## Claims and provider recipes
 
-Production issuer and callback URLs require HTTPS; HTTP is loopback-only. Introspection is the supported 3.13.104 verification mode and requires a client secret. `jwks` fails during configuration until an application cryptography capability is available.
+```ini
+TINA4_SSO_CLAIM_MAP={"username":"preferred_username","roles":"realm_access.roles","groups":"groups"}
+```
+
+The runtime does not name providers. Keycloak uses a realm issuer such as
+`https://sso.example.com/realms/my-realm`. Microsoft Entra ID uses its
+tenant-specific v2 issuer. Register the exact callback URI and map claims only
+when roles or groups use different names.
+
+Version 3.13.104 supports introspection without another gem and requires a
+client secret. Selecting `jwks` fails during configuration until the application
+installs a supported cryptography capability. State, nonce, code, and verifier
+are one-use. Logout always destroys the local Session first.
+
+When configured, Swagger publishes the issuer discovery URL as an
+`openIdConnect` scheme.

--- a/docs/ruby/41-gis.md
+++ b/docs/ruby/41-gis.md
@@ -1,18 +1,50 @@
 # GIS and PostGIS
 
-Tina4 stores geographic points in PostGIS, queries distance in metres, and returns GeoJSON. Coordinates are always `[longitude, latitude]`.
+Tina4 stores geographic points in PostGIS, measures distance in metres, and
+returns map-ready GeoJSON. Coordinates always use longitude first. GPS may
+supply coordinates, but GIS is the feature.
+
+## Define a point field
+
+Enable PostGIS with `CREATE EXTENSION IF NOT EXISTS postgis;`.
 
 ```ruby
+class ChargePoint < Tina4::ORM
+  point_field :location
+end
+
 site.location = Tina4::Point.new(18.4241, -33.9249)
 site.save
+```
 
+Tina4 creates `geography(Point,4326)` and an idempotent GiST index. Unsupported
+database engines and PostgreSQL without PostGIS fail clearly.
+`Tina4::Point.parse` accepts a Point, number pair, WKT or EWKT, GeoJSON Point or
+Feature, and WKB or EWKB. It rejects invalid ranges, non-finite numbers,
+non-point geometry, and conflicting SRIDs before SQL runs.
+
+## Query and return GeoJSON
+
+```ruby
 nearby = ChargePoint.query
   .within_distance("location", [18.42, -33.92], 5_000)
-  .select_distance("location", [18.42, -33.92])
+  .select_distance("location", [18.42, -33.92], alias_name: "metres")
   .order_by_distance("location", [18.42, -33.92])
   .get
 
 feature = site.to_feature
+collection = Tina4::ORM.feature_collection(nearby)
 ```
 
-`PointField` maps to `geography(Point,4326)` and creates a GiST index. Unsupported database engines fail clearly. `Tina4::Point.parse` accepts coordinate pairs, WKT/EWKT, GeoJSON, or WKB/EWKB and never guesses coordinate order.
+The query builder also provides `intersects` for bound WKT, EWKT, or GeoJSON
+geometry and `bbox` for a validated bounding box. Spatial values use bound
+parameters. Column and alias names are validated as identifiers.
+
+`to_feature` moves the chosen Point into `geometry` and keeps other selected
+fields in `properties`. A null point creates `"geometry": null`.
+`feature_collection` preserves query order. Supply a geometry field for models
+with several Point fields and an include list to limit properties.
+
+Version 3.13.104 persists Point fields only. It does not persist lines,
+polygons, rasters, tiles, geocoding results, or routes. `intersects` may accept a
+polygon as query geometry. PostGIS is the only storage provider.

--- a/docs/ruby/42-iot-mqtt.md
+++ b/docs/ruby/42-iot-mqtt.md
@@ -1,0 +1,50 @@
+# IoT and MQTT
+
+Tina4 includes a zero-dependency MQTT 3.1.1 client for telemetry, device state,
+asset tracking, and EV charging. It connects to an external broker such as
+Mosquitto, EMQX, HiveMQ, or AWS IoT. Tina4 is not a broker.
+
+## Configure and publish
+
+```ini
+TINA4_MQTT_URL=mqtt://127.0.0.1:1883
+TINA4_MQTT_CLIENT_ID=warehouse-api
+TINA4_MQTT_KEEPALIVE=60
+TINA4_MQTT_TLS_VERIFY=true
+TINA4_MQTT_CA_FILE=/run/secrets/mqtt-ca.pem
+```
+
+Use `mqtt://` or `tcp://` for plain TCP and `mqtts://` for TLS. Put credentials
+in URL user information or constructor arguments. There are no username or
+password environment variables.
+
+```ruby
+mqtt = Tina4::Mqtt.new
+packet_id = mqtt.publish(
+  "fleet/meter-42/telemetry",
+  '{"kwh":12.5}',
+  qos: 1
+)
+mqtt.disconnect
+```
+
+Construction connects by default. QoS 0 waits for no acknowledgement. QoS 1
+returns the packet id after PUBACK. Tina4 refuses QoS 2.
+
+```ruby
+mqtt = Tina4::Mqtt.new(clean_session: false)
+mqtt.consume("fleet/+/telemetry", qos: 1) do |message|
+  process(message.topic, message.to_s)
+end
+```
+
+`consume` acknowledges after successful block handling. Use
+`receive(ack: false)` followed by `message.acknowledge` for manual control.
+Messages expose topic, byte payload, QoS, packet id, retained and duplicate
+flags, acknowledgement, text through `to_s`, and `to_h`.
+
+Retained publishes store current state; an empty retained payload clears it.
+Configure `will_topic`, `will_payload`, `will_qos`, and `will_retain` for an
+unclean disconnect. `disconnect` suppresses the will; `kill` lets the broker
+publish it. TLS verification defaults to true. `tls?`, `cipher`, and
+`tls_version` report the connection. One client has one socket reader.

--- a/docs/ruby/index.md
+++ b/docs/ruby/index.md
@@ -559,6 +559,21 @@ fake = Tina4::FakeData.new(seed: 42)
 
 Use `FakeData` in tests and migrations to generate consistent fixture data without external gems.
 
+### OpenID Connect SSO <a href="#sso" id="sso"></a>
+
+Configure any standard OIDC issuer, then use the normal secured-route gate and
+Tina4 Session. See [OpenID Connect SSO](./40-sso.md) for the complete client API.
+
+### GIS and PostGIS <a href="#gis" id="gis"></a>
+
+Declare a Point field, query metres, and return GeoJSON. Coordinates are
+longitude then latitude. See [GIS and PostGIS](./41-gis.md).
+
+### IoT and MQTT <a href="#iot-mqtt" id="iot-mqtt"></a>
+
+Use the MQTT 3.1.1 client for QoS 0/1 telemetry, retained state, Last Will, and
+verified TLS. See [IoT and MQTT](./42-iot-mqtt.md).
+
 ***
 
 ## 📕 Download the book

--- a/plan/sso-gis-iot-docs.md
+++ b/plan/sso-gis-iot-docs.md
@@ -43,6 +43,6 @@ language quick reference and sidebar, with examples that match the released
 
 ## Commits
 
-- Pending.
+- `ac52dbe` - complete the SSO, GIS, and IoT/MQTT documentation across all four backends.
 
 ## Status: In progress

--- a/plan/sso-gis-iot-docs.md
+++ b/plan/sso-gis-iot-docs.md
@@ -1,0 +1,48 @@
+# Task: Complete SSO, GIS, and IoT documentation
+
+**Outcome:** A developer can discover and use SSO, GIS, and MQTT from every
+language quick reference and sidebar, with examples that match the released
+3.13.104 APIs.
+
+## Scope
+
+- [x] Audit public chapters, quick references, sidebar registration, and live URLs.
+- [x] Read Features 94, 136, and 137 plus ADR-0056 and ADR-0057.
+- [x] Expand all four SSO chapters to the complete public lifecycle and security contract.
+- [x] Expand all four GIS chapters to the complete Point, query, and GeoJSON contract.
+- [x] Add one IoT/MQTT chapter for each backend with the idiomatic released API.
+- [x] Add SSO, GIS, and IoT/MQTT to all four quick references.
+- [x] Register all three chapter stems in the shared backend sidebar.
+- [x] Build the site, run strict truth/link/catalog audits, and check rendered pages.
+- [ ] Merge to documentation `main` and verify tina4.com navigation.
+
+## Parity
+
+| Documentation | Python | PHP | Ruby | Node.js |
+| --- | --- | --- | --- | --- |
+| SSO chapter | Complete | Complete | Complete | Complete |
+| GIS chapter | Complete | Complete | Complete | Complete |
+| IoT/MQTT chapter | Complete | Complete | Complete | Complete |
+| Quick reference | Complete | Complete | Complete | Complete |
+| Sidebar | Complete | Complete | Complete | Complete |
+
+## Tests
+
+- [x] Every documented `tina4` command and `TINA4_*` variable passes `audit-truth.py --strict --strict-env`.
+- [x] Every internal link and anchor passes `audit-links.py --strict --strict-anchors`.
+- [x] The feature catalog audit passes.
+- [x] Tina4Press builds every page.
+- [x] Rendered navigation contains SSO, GIS, and IoT/MQTT for all four backends.
+- [ ] Live chapter URLs return 200 after deployment.
+
+## Bugs
+
+- [x] DOC-NAV-SSO-GIS: SSO and GIS pages exist but have no sidebar or quick-reference entry.
+- [x] DOC-IOT-MISSING: MQTT ships in all four frameworks but has no public guide.
+- [x] DOC-PARITY-SHALLOW: PHP, Ruby, and Node.js SSO/GIS pages omit major public operations.
+
+## Commits
+
+- Pending.
+
+## Status: In progress

--- a/tina4press.config.mjs
+++ b/tina4press.config.mjs
@@ -101,7 +101,8 @@ const BACKEND_GROUPS = [
   {
     text: "APIs & Protocols",
     stems: ["swagger", "api-client", "graphql", "websocket", "sse",
-            "wsdl-soap", "realtime-webrtc", "ai-client"],
+            "wsdl-soap", "realtime-webrtc", "ai-client", "sso", "gis",
+            "iot-mqtt"],
   },
   {
     text: "Advanced",


### PR DESCRIPTION
## Summary\n- make SSO and GIS discoverable in every backend sidebar and quick reference\n- add complete IoT/MQTT guides for Python, PHP, Ruby, and Node.js\n- expand all SSO and GIS chapters against the released 3.13.104 APIs\n\n## Validation\n- audit-truth.py --strict --strict-env\n- audit-links.py --strict --strict-anchors\n- audit-feature-catalog.py\n- Tina4Press build (288 pages)