### PR TITLE
docs: register staging mail safety controls

### DIFF
--- a/docs/general/04-environment-variables.md
+++ b/docs/general/04-environment-variables.md
@@ -348,6 +348,8 @@ Tina4 supports two naming conventions for SMTP variables. The `SMTP_*` variables
 | `TINA4_MAIL_FROM` | `TINA4_MAIL_FROM` | `noreply@localhost` | Default sender address. |
 | `TINA4_MAIL_FROM_NAME` | `TINA4_MAIL_FROM_NAME` | _(none)_ | Sender display name. |
 | `TINA4_MAIL_ENCRYPTION` | - | `tls` | Connection encryption. `tls`, `ssl`, or `none`. |
+| `TINA4_MAIL_CAPTURE` | - | `false` | Force local DevMailbox capture and skip SMTP, even when a host exists. |
+| `TINA4_MAIL_REDIRECT_TO` | - | _(none)_ | Replace every SMTP recipient with a comma-separated safety list. |
 
 #### IMAP (for reading email)
 
@@ -396,7 +398,21 @@ Tina4 supports two naming conventions for SMTP variables. The `SMTP_*` variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TINA4_MAILBOX_DIR` | `data/mailbox` | Directory for captured dev emails. |
+| `TINA4_MAILBOX_DIR` | `data/mailbox` | Directory for captured mail. It does not control whether capture runs. |
+
+`TINA4_DEBUG` exposes the mailbox in the developer dashboard but does not stop
+SMTP. On staging, choose one explicit safety policy:
+
+```bash
+# Keep all mail inside the application.
+TINA4_MAIL_CAPTURE=true
+
+# Or exercise SMTP while replacing every original To, Cc, and Bcc recipient.
+TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com
+```
+
+Capture wins if both settings exist. Redirect applies only to real SMTP
+delivery and records the original recipients in `X-Tina4-Original-To`.
 
 ---
 
@@ -575,15 +591,15 @@ TINA4_SWAGGER_VERSION=1.0.0
 | 14 | Sessions (base + Redis + Valkey + MongoDB) |
 | 15 | Queue (base + RabbitMQ + Kafka + MongoDB) |
 | 5 | Response cache |
-| 8 | Messenger (SMTP + IMAP) |
+| 10 | Messenger (SMTP + IMAP + staging safety) |
 | 2 | Localization |
 | 3 | Swagger |
 | 1 | File uploads |
 | 3 | WebSocket |
 | 2 | Services |
 | 1 | Dev mailbox |
-| **82** | **Total** |
+| **84** | **Total** |
 
 Every variable follows the same priority chain: constructor > `.env` > default. Every boolean is interpreted consistently across all four frameworks. Every variable has a sensible default that works for development without any configuration.
 
-One file. Eighty-two knobs. Turn what you need. Leave the rest alone.
+One file. Eighty-four knobs. Turn what you need. Leave the rest alone.

--- a/docs/nodejs/16-email.md
+++ b/docs/nodejs/16-email.md
@@ -4,7 +4,7 @@
 
 Signup confirmations. Password resets. Weekly digests. Invoices with PDF attachments. Every application needs email. Nobody enjoys building it.
 
-SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. The details pile up fast. Tina4's `Messenger` class absorbs all of it. Configure through `.env`. Create an instance. Send. In development mode, Messenger intercepts every outgoing email and displays it in the dev dashboard -- no real SMTP server required.
+SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. The details pile up fast. Tina4's `Messenger` class absorbs all of it. Configure through `.env`. Create an instance. Send. Without an SMTP host, Messenger captures mail in the dev mailbox. An SMTP host enables real delivery, so staging needs an explicit safety setting.
 
 ---
 
@@ -31,6 +31,34 @@ TINA4_MAIL_FROM_NAME=My Store
 | `TINA4_MAIL_ENCRYPTION` | Encryption method | `tls` (recommended), `ssl`, `none` |
 | `TINA4_MAIL_FROM` | Default "From" address | `noreply@yourdomain.com` |
 | `TINA4_MAIL_FROM_NAME` | Default "From" display name | `My Store`, `Acme Corp` |
+| `TINA4_MAIL_CAPTURE` | Disable SMTP and capture each message locally | `true` on staging when no external delivery is allowed |
+| `TINA4_MAIL_REDIRECT_TO` | Replace every SMTP recipient with a safety list | `qa@example.com,product@example.com` |
+
+### Staging delivery safety
+
+`TINA4_DEBUG` controls developer tools. It does not disable SMTP delivery. Pick
+one explicit mail policy for staging:
+
+```bash
+# No message leaves the application. Inspect it in the dev mailbox.
+TINA4_MAIL_CAPTURE=true
+```
+
+Capture wins even when an SMTP host exists. A missing SMTP host also captures
+mail. `TINA4_MAILBOX_DIR` only selects the dev mailbox directory; it does not
+turn capture on or off.
+
+Use real SMTP without risking customer delivery by replacing all recipients:
+
+```bash
+TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com
+```
+
+Tina4 trims each comma-separated address and drops blank entries. On the SMTP
+path, the safety list replaces `To`; Tina4 clears `Cc` and `Bcc` and stores all
+original recipients in `X-Tina4-Original-To`. An unset or empty list leaves
+delivery unchanged. If capture and redirect are both set, capture wins and
+nothing reaches SMTP.
 
 ### Common Provider Configurations
 
@@ -489,9 +517,11 @@ if (result.success) {
 
 ---
 
-## 10. Dev Mode: Email Interception
+## 10. Dev Mailbox Capture
 
-When `TINA4_DEBUG=true`, Tina4 intercepts all outgoing emails and stores them locally. No real recipients receive anything. No accidental emails during development.
+Messenger captures outgoing mail when no SMTP host exists or when
+`TINA4_MAIL_CAPTURE=true`. `TINA4_DEBUG` only makes the dev dashboard available;
+it does not change delivery.
 
 Navigate to `/__dev` and look for the "Mail" section. You see:
 
@@ -501,25 +531,21 @@ Navigate to `/__dev` and look for the "Mail" section. You see:
 - Attachments (viewable inline)
 - The timestamp
 
-This is invaluable for testing email functionality without configuring a real SMTP server. Use `createMessenger()` instead of `new Messenger()` to get automatic dev-mode interception:
+Use `createMessenger()` to load the environment policy and capture without an SMTP host:
 
 ```typescript
 import { createMessenger } from "tina4-nodejs";
 
 const mailer = createMessenger();
-// In dev mode: captures locally
-// In production: sends via SMTP
+// No SMTP host or TINA4_MAIL_CAPTURE=true: captures locally
+// SMTP host configured and capture off: sends through SMTP
 ```
 
-### Disabling Interception
+### Sending from a development environment
 
-If you need to test real email delivery during development, override the interception:
-
-```bash
-TINA4_MAILBOX_DIR=false
-```
-
-With this set, emails reach real recipients even when `TINA4_DEBUG=true`. Use with caution -- you do not want to accidentally email your entire user base from a dev machine.
+Configure an SMTP host and leave `TINA4_MAIL_CAPTURE` unset or false. The
+`TINA4_DEBUG` value does not matter to delivery. To test SMTP without reaching
+customers, set `TINA4_MAIL_REDIRECT_TO` to controlled inboxes.
 
 ---
 
@@ -640,7 +666,7 @@ curl -X POST http://localhost:7148/api/register \
 }
 ```
 
-With `TINA4_DEBUG=true`, the email appears in the dev dashboard instead of reaching a real inbox. Inspect the rendered HTML, check that template variables substituted, and verify the layout.
+With `TINA4_MAIL_CAPTURE=true`, the email stays in the dev mailbox instead of reaching a real inbox. Enable `TINA4_DEBUG=true` to inspect the rendered HTML and verify the template values in the dashboard.
 
 ---
 
@@ -957,9 +983,9 @@ The HTML response includes the success flash message.
 
 **Problem:** You configured SMTP but no emails arrive. No errors either.
 
-**Cause:** `TINA4_DEBUG=true` intercepts all emails and stores them in the dev dashboard. The email never reaches the SMTP server.
+**Cause:** `TINA4_MAIL_CAPTURE=true` or a missing SMTP host sends mail to the dev mailbox. `TINA4_DEBUG` does not control delivery.
 
-**Fix:** Check the dev dashboard at `/__dev` for intercepted emails. If you want to send real emails during development, set `TINA4_MAILBOX_DIR=false`. Remove this setting before committing.
+**Fix:** Check `/__dev` for captured mail. To use SMTP, configure `TINA4_MAIL_HOST` and remove `TINA4_MAIL_CAPTURE`. On staging, set `TINA4_MAIL_REDIRECT_TO` so tests cannot reach customer addresses.
 
 ### 6. Email Template Variables Not Substituted
 

--- a/docs/nodejs/33-environment-variables.md
+++ b/docs/nodejs/33-environment-variables.md
@@ -215,7 +215,11 @@ This chapter lists every variable the Node.js framework reads, grouped by subsys
 | `TINA4_MAIL_IMAP_HOST` | _(none)_ | IMAP server for inbound mail. |
 | `TINA4_MAIL_IMAP_PORT` | `993` | IMAP server port. |
 | `TINA4_MAIL_IMAP_ENCRYPTION` | `tls` | IMAP transport security. Options: `tls`, `starttls`, `none`. Node also accepts `ssl` as an alias for `tls` for back-compat. |
-| `TINA4_MAILBOX_DIR` | `data/mailbox` | Dev mailbox directory. All outbound mail lands here when `TINA4_DEBUG=true`. |
+| `TINA4_MAIL_CAPTURE` | `false` | Force local DevMailbox capture and skip SMTP, even when an SMTP host exists. A missing host also captures. |
+| `TINA4_MAIL_REDIRECT_TO` | _(none)_ | Comma-separated safety recipients for real SMTP delivery. Replaces To, Cc, and Bcc. |
+| `TINA4_MAILBOX_DIR` | `data/mailbox` | Storage directory for captured mail. This setting does not enable or disable capture. |
+
+> `TINA4_DEBUG` does not suppress email. On staging, set `TINA4_MAIL_CAPTURE=true` to keep every message local, or set `TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com` to exercise SMTP without reaching original recipients. Capture takes precedence when both are set.
 
 > `TINA4_MAIL_HOST`, `TINA4_MAIL_PORT`, `TINA4_MAIL_USERNAME`, `TINA4_MAIL_PASSWORD`, `TINA4_MAIL_FROM`, `TINA4_MAIL_FROM_NAME`, `TINA4_MAIL_IMAP_HOST`, `TINA4_MAIL_IMAP_PORT`, `TINA4_MAIL_IMAP_USERNAME`, `TINA4_MAIL_IMAP_PASSWORD` are accepted as legacy aliases. New projects should use the `TINA4_MAIL_*` names.
 

--- a/docs/php/16-email.md
+++ b/docs/php/16-email.md
@@ -6,7 +6,7 @@ Your SaaS app needs signup confirmations. Password resets. Weekly digests. Attac
 
 Email is plumbing. Every application needs it. Nobody wants to build it. SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. Bounce handling. The details pile up.
 
-Tina4's `Messenger` class handles all of it. Configure in `.env`. Create an instance. Send. In development mode, emails land in the dev dashboard -- not in real inboxes. No accidents.
+Tina4's `Messenger` class handles all of it. Configure in `.env`. Create an instance. Send. Without an SMTP host, Messenger captures mail in the dev mailbox. An SMTP host enables real delivery, so staging needs an explicit safety setting.
 
 ---
 
@@ -33,6 +33,34 @@ TINA4_MAIL_FROM_NAME=My Store
 | `TINA4_MAIL_ENCRYPTION` | Encryption method | `tls` (recommended), `ssl`, `none` |
 | `TINA4_MAIL_FROM` | Default "From" address | `noreply@yourdomain.com` |
 | `TINA4_MAIL_FROM_NAME` | Default "From" display name | `My Store`, `Acme Corp` |
+| `TINA4_MAIL_CAPTURE` | Disable SMTP and capture each message locally | `true` on staging when no external delivery is allowed |
+| `TINA4_MAIL_REDIRECT_TO` | Replace every SMTP recipient with a safety list | `qa@example.com,product@example.com` |
+
+### Staging delivery safety
+
+`TINA4_DEBUG` controls developer tools. It does not disable SMTP delivery. Pick
+one explicit mail policy for staging:
+
+```bash
+# No message leaves the application. Inspect it in the dev mailbox.
+TINA4_MAIL_CAPTURE=true
+```
+
+Capture wins even when an SMTP host exists. A missing SMTP host also captures
+mail. `TINA4_MAILBOX_DIR` only selects the dev mailbox directory; it does not
+turn capture on or off.
+
+Use real SMTP without risking customer delivery by replacing all recipients:
+
+```bash
+TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com
+```
+
+Tina4 trims each comma-separated address and drops blank entries. On the SMTP
+path, the safety list replaces `To`; Tina4 clears `Cc` and `Bcc` and stores all
+original recipients in `X-Tina4-Original-To`. An unset or empty list leaves
+delivery unchanged. If capture and redirect are both set, capture wins and
+nothing reaches SMTP.
 
 ### Common Provider Configurations
 
@@ -473,9 +501,11 @@ Pass the `folder` option to read from any IMAP folder. The default is `"INBOX"`.
 
 ---
 
-## 10. Dev Mode: Email Interception
+## 10. Dev Mailbox Capture
 
-When `TINA4_DEBUG=true`, all outgoing emails are intercepted. They appear in the dev dashboard instead of reaching real recipients. No accidents during development.
+Messenger captures outgoing mail when no SMTP host exists or when
+`TINA4_MAIL_CAPTURE=true`. `TINA4_DEBUG` only makes the dev dashboard available;
+it does not change delivery.
 
 Navigate to `/__dev` and find the "Mail" section. You see:
 
@@ -485,17 +515,13 @@ Navigate to `/__dev` and find the "Mail" section. You see:
 - Attachments (viewable inline)
 - The timestamp
 
-Test email without configuring a real SMTP server. Inspect the output without polluting anyone's inbox.
+Test email without configuring a real SMTP server. Enable `TINA4_DEBUG=true` to inspect captured messages in the dashboard.
 
-### Disabling Interception
+### Sending from a development environment
 
-To test real email delivery during development:
-
-```bash
-TINA4_MAILBOX_DIR=false
-```
-
-Emails now reach real recipients even when `TINA4_DEBUG=true`. Use with caution. You do not want to email your entire user base from a dev machine.
+Configure an SMTP host and leave `TINA4_MAIL_CAPTURE` unset or false. The
+`TINA4_DEBUG` value does not matter to delivery. To test SMTP without reaching
+customers, set `TINA4_MAIL_REDIRECT_TO` to controlled inboxes.
 
 ---
 
@@ -618,7 +644,7 @@ curl -X POST http://localhost:7145/api/register \
 }
 ```
 
-With `TINA4_DEBUG=true`, the email appears in the dev dashboard. Inspect the rendered HTML. Check that template variables were substituted. Verify the layout.
+With `TINA4_MAIL_CAPTURE=true`, the email stays in the dev mailbox instead of reaching a real inbox. Enable `TINA4_DEBUG=true` to inspect the rendered HTML and verify the template values in the dashboard.
 
 ---
 
@@ -950,9 +976,9 @@ The HTML response includes the success flash message.
 
 **Problem:** You set up SMTP. No emails arrive. No errors either.
 
-**Cause:** `TINA4_DEBUG=true` intercepts all emails and shows them in the dev dashboard. The email never reaches the SMTP server.
+**Cause:** `TINA4_MAIL_CAPTURE=true` or a missing SMTP host sends mail to the dev mailbox. `TINA4_DEBUG` does not control delivery.
 
-**Fix:** Check the dev dashboard at `/__dev` for intercepted emails. If you need real email delivery during development, set `TINA4_MAILBOX_DIR=false`. Remove this setting before committing.
+**Fix:** Check `/__dev` for captured mail. To use SMTP, configure `TINA4_MAIL_HOST` and remove `TINA4_MAIL_CAPTURE`. On staging, set `TINA4_MAIL_REDIRECT_TO` so tests cannot reach customer addresses.
 
 ### 6. Email Template Variables Not Substituted
 

--- a/docs/php/33-environment-variables.md
+++ b/docs/php/33-environment-variables.md
@@ -234,7 +234,11 @@ This chapter lists every variable the PHP framework reads, grouped by subsystem.
 | `TINA4_MAIL_IMAP_USERNAME` | _(none)_ | IMAP authentication username. |
 | `TINA4_MAIL_IMAP_PASSWORD` | _(none)_ | IMAP authentication password. |
 | `TINA4_MAIL_IMAP_ENCRYPTION` | `tls` | IMAP transport encryption. Accepts `tls`, `starttls`, or `none`; any other value is silently coerced back to `tls`. Independent of `TINA4_MAIL_ENCRYPTION` so Gmail-style setups can use IMAPS on 993 alongside SMTP STARTTLS on 587. |
-| `TINA4_MAILBOX_DIR` | `data/mailbox` | Dev mailbox directory. All outbound mail lands here when `TINA4_DEBUG=true`. |
+| `TINA4_MAIL_CAPTURE` | `false` | Force local DevMailbox capture and skip SMTP, even when an SMTP host exists. A missing host also captures. |
+| `TINA4_MAIL_REDIRECT_TO` | _(none)_ | Comma-separated safety recipients for real SMTP delivery. Replaces To, Cc, and Bcc. |
+| `TINA4_MAILBOX_DIR` | `data/mailbox` | Storage directory for captured mail. This setting does not enable or disable capture. |
+
+> `TINA4_DEBUG` does not suppress email. On staging, set `TINA4_MAIL_CAPTURE=true` to keep every message local, or set `TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com` to exercise SMTP without reaching original recipients. Capture takes precedence when both are set.
 
 > `TINA4_MAIL_HOST`, `TINA4_MAIL_PORT`, `TINA4_MAIL_USERNAME`, `TINA4_MAIL_PASSWORD` are also accepted as aliases for the `TINA4_MAIL_*` equivalents. New projects should use the `TINA4_MAIL_*` names.
 

--- a/docs/python/16-email.md
+++ b/docs/python/16-email.md
@@ -4,7 +4,7 @@
 
 Signup confirmations. Password resets. Weekly digests. Invoices with PDF attachments. Every application needs email. Nobody enjoys building it.
 
-SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. The details pile up fast. Tina4's `Messenger` class absorbs all of it. Configure through `.env`. Create an instance. Send. In development mode, Messenger intercepts every outgoing email and displays it in the dev dashboard -- no real SMTP server required.
+SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. The details pile up fast. Tina4's `Messenger` class absorbs all of it. Configure through `.env`. Create an instance. Send. Without an SMTP host, Messenger captures mail in the dev mailbox. An SMTP host enables real delivery, so staging needs an explicit safety setting.
 
 ---
 
@@ -31,8 +31,36 @@ TINA4_MAIL_FROM_NAME=My Store
 | `TINA4_MAIL_ENCRYPTION` | Encryption method | `tls` (recommended), `ssl`, `none` |
 | `TINA4_MAIL_FROM` | Default "From" address | `noreply@yourdomain.com` |
 | `TINA4_MAIL_FROM_NAME` | Default "From" display name | `My Store`, `Acme Corp` |
+| `TINA4_MAIL_CAPTURE` | Disable SMTP and capture each message locally | `true` on staging when no external delivery is allowed |
+| `TINA4_MAIL_REDIRECT_TO` | Replace every SMTP recipient with a safety list | `qa@example.com,product@example.com` |
 
 Messenger also accepts legacy `SMTP_*` prefixed variables as fallback. The `TINA4_MAIL_*` prefix takes priority.
+
+### Staging delivery safety
+
+`TINA4_DEBUG` controls developer tools. It does not disable SMTP delivery. Pick
+one explicit mail policy for staging:
+
+```bash
+# No message leaves the application. Inspect it in the dev mailbox.
+TINA4_MAIL_CAPTURE=true
+```
+
+Capture wins even when an SMTP host exists. A missing SMTP host also captures
+mail. `TINA4_MAILBOX_DIR` only selects the dev mailbox directory; it does not
+turn capture on or off.
+
+Use real SMTP without risking customer delivery by replacing all recipients:
+
+```bash
+TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com
+```
+
+Tina4 trims each comma-separated address and drops blank entries. On the SMTP
+path, the safety list replaces `To`; Tina4 clears `Cc` and `Bcc` and stores all
+original recipients in `X-Tina4-Original-To`. An unset or empty list leaves
+delivery unchanged. If capture and redirect are both set, capture wins and
+nothing reaches SMTP.
 
 ### Common Provider Configurations
 
@@ -473,9 +501,11 @@ else:
 
 ---
 
-## 10. Dev Mode: Email Interception
+## 10. Dev Mailbox Capture
 
-When `TINA4_DEBUG=true`, Tina4 intercepts all outgoing emails and stores them locally. No real recipients receive anything. No accidental emails during development.
+Messenger captures outgoing mail when no SMTP host exists or when
+`TINA4_MAIL_CAPTURE=true`. `TINA4_DEBUG` only makes the dev dashboard available;
+it does not change delivery.
 
 Navigate to `/__dev` and look for the "Mail" section. You see:
 
@@ -485,25 +515,21 @@ Navigate to `/__dev` and look for the "Mail" section. You see:
 - Attachments (viewable inline)
 - The timestamp
 
-This is invaluable for testing email functionality without configuring a real SMTP server. Use `create_messenger()` instead of `Messenger()` to get automatic dev-mode interception:
+Use `create_messenger()` to load the environment policy and capture without an SMTP host:
 
 ```python
 from tina4_python.messenger import create_messenger
 
 mailer = create_messenger()
-# In dev mode: captures locally
-# In production: sends via SMTP
+# No SMTP host or TINA4_MAIL_CAPTURE=true: captures locally
+# SMTP host configured and capture off: sends through SMTP
 ```
 
-### Disabling Interception
+### Sending from a development environment
 
-If you need to test real email delivery during development, override the interception:
-
-```bash
-TINA4_MAILBOX_DIR=false
-```
-
-With this set, emails reach real recipients even when `TINA4_DEBUG=true`. Use with caution -- you do not want to accidentally email your entire user base from a dev machine.
+Configure an SMTP host and leave `TINA4_MAIL_CAPTURE` unset or false. The
+`TINA4_DEBUG` value does not matter to delivery. To test SMTP without reaching
+customers, set `TINA4_MAIL_REDIRECT_TO` to controlled inboxes.
 
 ---
 
@@ -628,7 +654,7 @@ curl -X POST http://localhost:7146/api/register \
 }
 ```
 
-With `TINA4_DEBUG=true`, the email appears in the dev dashboard instead of reaching a real inbox. Inspect the rendered HTML, check that template variables substituted, and verify the layout.
+With `TINA4_MAIL_CAPTURE=true`, the email stays in the dev mailbox instead of reaching a real inbox. Enable `TINA4_DEBUG=true` to inspect the rendered HTML and verify the template values in the dashboard.
 
 ---
 
@@ -961,9 +987,9 @@ The HTML response includes the success flash message.
 
 **Problem:** You configured SMTP but no emails arrive. No errors either.
 
-**Cause:** `TINA4_DEBUG=true` intercepts all emails and stores them in the dev dashboard. The email never reaches the SMTP server.
+**Cause:** `TINA4_MAIL_CAPTURE=true` or a missing SMTP host sends mail to the dev mailbox. `TINA4_DEBUG` does not control delivery.
 
-**Fix:** Check the dev dashboard at `/__dev` for intercepted emails. If you want to send real emails during development, set `TINA4_MAILBOX_DIR=false`. Remove this setting before committing.
+**Fix:** Check `/__dev` for captured mail. To use SMTP, configure `TINA4_MAIL_HOST` and remove `TINA4_MAIL_CAPTURE`. On staging, set `TINA4_MAIL_REDIRECT_TO` so tests cannot reach customer addresses.
 
 ### 6. Email Template Variables Not Substituted
 

--- a/docs/python/33-environment-variables.md
+++ b/docs/python/33-environment-variables.md
@@ -222,7 +222,11 @@ This chapter lists every variable the Python framework reads, grouped by subsyst
 | `TINA4_MAIL_IMAP_HOST` | _(none)_ | IMAP server for inbound mail. |
 | `TINA4_MAIL_IMAP_PORT` | `993` | IMAP server port. |
 | `TINA4_MAIL_IMAP_ENCRYPTION` | `tls` | IMAP transport encryption. Options: `tls`, `starttls`, `none`. Invalid values fall back to `tls` so a typo can't accidentally disable encryption. |
-| `TINA4_MAILBOX_DIR` | `data/mailbox` | Dev mailbox directory. All outbound mail lands here when `TINA4_DEBUG=true`. |
+| `TINA4_MAIL_CAPTURE` | `false` | Force local DevMailbox capture and skip SMTP, even when an SMTP host exists. A missing host also captures. |
+| `TINA4_MAIL_REDIRECT_TO` | _(none)_ | Comma-separated safety recipients for real SMTP delivery. Replaces To, Cc, and Bcc. |
+| `TINA4_MAILBOX_DIR` | `data/mailbox` | Storage directory for captured mail. This setting does not enable or disable capture. |
+
+> `TINA4_DEBUG` does not suppress email. On staging, set `TINA4_MAIL_CAPTURE=true` to keep every message local, or set `TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com` to exercise SMTP without reaching original recipients. Capture takes precedence when both are set.
 
 > `TINA4_MAIL_HOST`, `TINA4_MAIL_PORT`, `TINA4_MAIL_USERNAME`, `TINA4_MAIL_PASSWORD`, `TINA4_MAIL_FROM`, `TINA4_MAIL_FROM_NAME`, `TINA4_MAIL_IMAP_HOST`, `TINA4_MAIL_IMAP_PORT` are accepted as legacy aliases. New projects should use the `TINA4_MAIL_*` names.
 

--- a/docs/ruby/16-email.md
+++ b/docs/ruby/16-email.md
@@ -4,7 +4,7 @@
 
 Signup confirmations. Password resets. Weekly digests. Invoices with PDF attachments. Every application needs email. Nobody enjoys building it.
 
-SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. Bounce handling. The details compound. Tina4's `Messenger` class owns all of it. Configure through `.env`. Create an instance. Send. In development mode, Messenger intercepts every outgoing email and displays it in the dev dashboard -- no real SMTP server required.
+SMTP configuration. Plain text fallbacks. Attachment encoding. Connection timeouts. Bounce handling. The details compound. Tina4's `Messenger` class owns all of it. Configure through `.env`. Create an instance. Send. Without an SMTP host, Messenger captures mail in the dev mailbox. An SMTP host enables real delivery, so staging needs an explicit safety setting.
 
 ---
 
@@ -31,8 +31,36 @@ TINA4_MAIL_FROM_NAME=My Store
 | `TINA4_MAIL_ENCRYPTION` | Encryption method | `tls` (recommended), `ssl`, `none` |
 | `TINA4_MAIL_FROM` | Default "From" address | `noreply@yourdomain.com` |
 | `TINA4_MAIL_FROM_NAME` | Default "From" display name | `My Store`, `Acme Corp` |
+| `TINA4_MAIL_CAPTURE` | Disable SMTP and capture each message locally | `true` on staging when no external delivery is allowed |
+| `TINA4_MAIL_REDIRECT_TO` | Replace every SMTP recipient with a safety list | `qa@example.com,product@example.com` |
 
 Messenger also accepts legacy `SMTP_*` prefixed variables as fallback. The `TINA4_MAIL_*` prefix takes priority.
+
+### Staging delivery safety
+
+`TINA4_DEBUG` controls developer tools. It does not disable SMTP delivery. Pick
+one explicit mail policy for staging:
+
+```bash
+# No message leaves the application. Inspect it in the dev mailbox.
+TINA4_MAIL_CAPTURE=true
+```
+
+Capture wins even when an SMTP host exists. A missing SMTP host also captures
+mail. `TINA4_MAILBOX_DIR` only selects the dev mailbox directory; it does not
+turn capture on or off.
+
+Use real SMTP without risking customer delivery by replacing all recipients:
+
+```bash
+TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com
+```
+
+Tina4 trims each comma-separated address and drops blank entries. On the SMTP
+path, the safety list replaces `To`; Tina4 clears `Cc` and `Bcc` and stores all
+original recipients in `X-Tina4-Original-To`. An unset or empty list leaves
+delivery unchanged. If capture and redirect are both set, capture wins and
+nothing reaches SMTP.
 
 ### Common Provider Configurations
 
@@ -418,9 +446,11 @@ folders = mailer.folders
 
 ---
 
-## 10. Dev Mode: Email Interception
+## 10. Dev Mailbox Capture
 
-When `TINA4_DEBUG=true`, Tina4 intercepts all outgoing emails and stores them locally. No real recipients receive anything. No accidental emails during development.
+Messenger captures outgoing mail when no SMTP host exists or when
+`TINA4_MAIL_CAPTURE=true`. `TINA4_DEBUG` only makes the dev dashboard available;
+it does not change delivery.
 
 Navigate to `/__dev` and click "Emails" to see:
 
@@ -430,17 +460,13 @@ Navigate to `/__dev` and click "Emails" to see:
 - Attachments list
 - Headers
 
-This means you can test email functionality without configuring SMTP during development.
+This lets you test email without configuring SMTP. Enable `TINA4_DEBUG=true` to browse captured messages in the dev dashboard.
 
-### Disabling Interception
+### Sending from a development environment
 
-If you need to test real email delivery during development, override the interception:
-
-```bash
-TINA4_MAILBOX_DIR=false
-```
-
-With this set, emails reach real recipients even when `TINA4_DEBUG=true`. Use with caution -- you do not want to accidentally email your entire user base from a dev machine.
+Configure an SMTP host and leave `TINA4_MAIL_CAPTURE` unset or false. The
+`TINA4_DEBUG` value does not matter to delivery. To test SMTP without reaching
+customers, set `TINA4_MAIL_REDIRECT_TO` to controlled inboxes.
 
 ---
 
@@ -539,7 +565,7 @@ curl -X POST http://localhost:7147/api/register \
 }
 ```
 
-With `TINA4_DEBUG=true`, the email appears in the dev dashboard instead of reaching a real inbox. Inspect the rendered HTML, check that template variables substituted, and verify the layout.
+With `TINA4_MAIL_CAPTURE=true`, the email stays in the dev mailbox instead of reaching a real inbox. Enable `TINA4_DEBUG=true` to inspect the rendered HTML and verify the template values in the dashboard.
 
 ---
 

--- a/docs/ruby/33-environment-variables.md
+++ b/docs/ruby/33-environment-variables.md
@@ -231,7 +231,11 @@ This chapter lists every variable the Ruby framework reads, grouped by subsystem
 | `TINA4_MAIL_IMAP_USERNAME` | _(inherits SMTP username)_ | IMAP authentication username. Mapped from legacy `IMAP_USER`. |
 | `TINA4_MAIL_IMAP_PASSWORD` | _(inherits SMTP password)_ | IMAP authentication password. Mapped from legacy `IMAP_PASS`. |
 | `TINA4_MAIL_IMAP_ENCRYPTION` | `tls` | IMAP connection encryption. Accepts `tls`, `starttls`, or `none`. |
-| `TINA4_MAILBOX_DIR` | `data/mailbox` | Dev mailbox directory. All outbound mail lands here when `TINA4_DEBUG=true`. |
+| `TINA4_MAIL_CAPTURE` | `false` | Force local DevMailbox capture and skip SMTP, even when an SMTP host exists. A missing host also captures. |
+| `TINA4_MAIL_REDIRECT_TO` | _(none)_ | Comma-separated safety recipients for real SMTP delivery. Replaces To, Cc, and Bcc. |
+| `TINA4_MAILBOX_DIR` | `data/mailbox` | Storage directory for captured mail. This setting does not enable or disable capture. |
+
+> `TINA4_DEBUG` does not suppress email. On staging, set `TINA4_MAIL_CAPTURE=true` to keep every message local, or set `TINA4_MAIL_REDIRECT_TO=qa@example.com,product@example.com` to exercise SMTP without reaching original recipients. Capture takes precedence when both are set.
 
 > `TINA4_MAIL_HOST`, `TINA4_MAIL_PORT`, `TINA4_MAIL_USERNAME`, `TINA4_MAIL_PASSWORD`, `TINA4_MAIL_FROM`, `TINA4_MAIL_FROM_NAME`, `TINA4_MAIL_IMAP_HOST`, `TINA4_MAIL_IMAP_PORT` are accepted as legacy aliases. New projects should use the `TINA4_MAIL_*` names.
 

--- a/plan/mail-staging-safety-docs.md
+++ b/plan/mail-staging-safety-docs.md
@@ -1,0 +1,43 @@
+# Task: Document staging mail safety controls
+
+**Outcome:** Developers can disable real delivery or redirect every recipient on
+staging from each language email guide and environment-variable registry.
+
+## Scope
+
+- [x] Verify the released behavior in all four framework implementations.
+- [x] Read the mail redirect and messenger contract fixtures.
+- [x] Document `TINA4_MAIL_CAPTURE` and `TINA4_MAIL_REDIRECT_TO` in all four email chapters.
+- [x] Register both variables in all four language environment references and the general registry.
+- [x] Remove the false claim that `TINA4_DEBUG` disables SMTP delivery.
+- [x] Synchronize the corrected chapters into `tina4-book`.
+- [ ] Build, audit, merge, and verify the live pages and regenerated PDFs.
+
+## Parity
+
+| Documentation | Python | PHP | Ruby | Node.js |
+| --- | --- | --- | --- | --- |
+| Email safety guide | Complete | Complete | Complete | Complete |
+| Environment registry | Complete | Complete | Complete | Complete |
+| Correct capture rule | Correct | Correct | Correct | Correct |
+
+## Tests
+
+- [x] Strict documentation truth audit passes.
+- [x] Strict link and anchor audit passes.
+- [x] Feature catalog audit passes.
+- [x] Tina4Press builds every page.
+- [ ] Source-book PDF build passes and mirrors the PDFs.
+- [ ] Live email and environment pages show both settings.
+
+## Bugs
+
+- [x] DOC-MAIL-SAFETY-MISSING: staging capture and recipient redirect are absent from public docs.
+- [x] DOC-MAIL-DEBUG-FALSE: the email guides claim debug mode suppresses delivery, but code does not.
+- [x] DOC-MAILBOX-DISABLE-FALSE: the guides recommend a mailbox-directory value as a delivery switch.
+
+## Commits
+
+- `f4955cc` - correct and expand the source-book mail safety documentation.
+
+## Status: In progress


### PR DESCRIPTION
## Summary\n- document mail capture and recipient redirect in every backend email guide\n- register both environment settings for all four languages and the general reference\n- remove unsafe claims that debug mode or the mailbox directory control SMTP delivery\n\n## Validation\n- audit-truth.py --strict --strict-env\n- audit-links.py --strict --strict-anchors\n- audit-feature-catalog.py\n- Tina4Press build: 288 pages